### PR TITLE
Add Apple SFSpeechRecognizer eval backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ poetry run ta analysis high-wer mazesmazes/tiny-audio --threshold 30
 poetry run ta analysis compare model1 model2
 ```
 
+### Apple SFSpeechRecognizer (macOS, on-device)
+
+```bash
+poetry run ta eval -m apple-speech -d loquacious -n 1000
+poetry run ta eval -m apple-speech --locale es-ES -d loquacious -n 100
+```
+
+Calls Apple's on-device `SFSpeechRecognizer` via PyObjC. macOS-only —
+`pyobjc-framework-Speech` is auto-installed on macOS via the Poetry
+`sys_platform == 'darwin'` marker. First run prompts for Speech Recognition
+consent (System Settings → Privacy & Security → Speech Recognition).
+
 ## CLI Reference
 
 All commands available via `tiny-audio` (or `ta` for short):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ torchaudio = ">=2.0.0"
 pyannote-core = ">=6.0.0"  # For DER metric calculation
 pyannote-metrics = ">=4.0.0"  # For DER metric calculation
 bitsandbytes = {version = "*", markers = "sys_platform == 'linux'"}
+pyobjc-framework-Speech = {version = "*", markers = "sys_platform == 'darwin'"}
 fabric = ">=3.0.0"
 pipecat-ai = {extras = ["openai", "silero"], version = "^0.0.98"}
 spacy = "^3.8.11"

--- a/scripts/eval/cli.py
+++ b/scripts/eval/cli.py
@@ -20,6 +20,7 @@ from scripts.eval.datasets import (
     load_eval_dataset,
 )
 from scripts.eval.evaluators import (
+    AppleSpeechEvaluator,
     AssemblyAIAlignmentEvaluator,
     AssemblyAIDiarizationEvaluator,
     AssemblyAIEvaluator,
@@ -437,7 +438,11 @@ def main(
     ctx: typer.Context,
     model: Annotated[
         Optional[str],
-        typer.Option("--model", "-m", help="Model path/ID, 'assemblyai', or 'deepgram'"),
+        typer.Option(
+            "--model",
+            "-m",
+            help="Model path/ID, 'assemblyai', 'deepgram', 'elevenlabs', or 'apple-speech'",
+        ),
     ] = None,
     datasets: Annotated[
         Optional[list[str]],
@@ -483,6 +488,13 @@ def main(
         Optional[str],
         typer.Option("--base-url", help="Custom API base URL (for AssemblyAI sandbox)"),
     ] = None,
+    locale: Annotated[
+        str,
+        typer.Option(
+            "--locale",
+            help="Locale for apple-speech (e.g. en-US, es-ES, fr-FR)",
+        ),
+    ] = "en-US",
     num_workers: Annotated[
         int,
         typer.Option("--num-workers", "-w", help="Number of parallel workers for API evaluations"),
@@ -784,6 +796,13 @@ def main(
                 audio_field=cfg.audio_field,
                 text_field=cfg.text_field,
                 num_workers=num_workers,
+            )
+        elif model == "apple-speech":
+            model_id = "apple-speech"
+            evaluator = AppleSpeechEvaluator(
+                locale=locale,
+                audio_field=cfg.audio_field,
+                text_field=cfg.text_field,
             )
         elif endpoint:
             model_id = get_model_name(model)

--- a/scripts/eval/evaluators/__init__.py
+++ b/scripts/eval/evaluators/__init__.py
@@ -11,6 +11,7 @@ from .alignment import (
     align_words_to_reference,
 )
 from .asr import (
+    AppleSpeechEvaluator,
     AssemblyAIEvaluator,
     AssemblyAIStreamingEvaluator,
     DeepgramEvaluator,
@@ -60,6 +61,7 @@ __all__ = [
     "AssemblyAIStreamingEvaluator",
     "DeepgramEvaluator",
     "ElevenLabsEvaluator",
+    "AppleSpeechEvaluator",
     # Diarization evaluators
     "DiarizationEvaluator",
     "AssemblyAIDiarizationEvaluator",

--- a/scripts/eval/evaluators/asr.py
+++ b/scripts/eval/evaluators/asr.py
@@ -1,7 +1,10 @@
 """ASR evaluator implementations."""
 
 import io
+import os
+import shutil
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -11,6 +14,19 @@ import torch
 from scripts.eval.audio import prepare_wav_bytes
 
 from .base import Evaluator, console, setup_assemblyai
+
+try:
+    from CoreFoundation import CFRunLoopRunInMode, kCFRunLoopDefaultMode
+    from Foundation import NSLocale, NSURL
+    from Speech import (
+        SFSpeechRecognizer,
+        SFSpeechRecognizerAuthorizationStatusAuthorized,
+        SFSpeechURLRecognitionRequest,
+    )
+
+    _APPLE_SPEECH_AVAILABLE = True
+except ImportError:
+    _APPLE_SPEECH_AVAILABLE = False
 
 
 def print_generation_config(model, model_path: str):
@@ -412,3 +428,126 @@ class ElevenLabsEvaluator(Evaluator):
         # Extract text from transcription response
         text = transcription.text if hasattr(transcription, "text") else str(transcription)
         return text or "", elapsed
+
+
+def _pump_run_loop_until(event: threading.Event, timeout_seconds: float) -> bool:
+    """Pump the main CF run loop in 50ms slices until event is set or timeout.
+
+    Speech.framework delivers callbacks via the main run loop; a plain
+    threading.Event.wait() starves the framework's XPC delivery and the
+    callback never fires.
+    """
+    deadline = time.time() + timeout_seconds
+    while not event.is_set():
+        if time.time() >= deadline:
+            return False
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, True)
+    return True
+
+
+class AppleSpeechEvaluator(Evaluator):
+    """Evaluator for Apple SFSpeechRecognizer (on-device, macOS only)."""
+
+    AUTH_TIMEOUT_SECONDS = 300.0
+    TRANSCRIBE_TIMEOUT_SECONDS = 60.0
+
+    def __init__(self, locale: str = "en-US", **kwargs):
+        if not _APPLE_SPEECH_AVAILABLE:
+            raise ImportError(
+                "Apple SFSpeechRecognizer backend requires PyObjC on macOS. "
+                "Install with: pip install pyobjc-framework-Speech"
+            )
+
+        if kwargs.get("num_workers", 1) > 1:
+            console.print(
+                "[yellow]Warning: AppleSpeechEvaluator forces num_workers=1 "
+                "(SFSpeechRecognizer is single-task)[/yellow]"
+            )
+            kwargs["num_workers"] = 1
+        super().__init__(**kwargs)
+
+        self.locale = locale
+        self.temp_dir = tempfile.mkdtemp(prefix="apple-speech-")
+        self._authorize()
+        self.recognizer = self._build_recognizer(locale)
+
+    def _authorize(self) -> None:
+        auth_event = threading.Event()
+        status_box = [None]
+
+        def handler(status):
+            status_box[0] = status
+            auth_event.set()
+
+        SFSpeechRecognizer.requestAuthorization_(handler)
+        if not _pump_run_loop_until(auth_event, self.AUTH_TIMEOUT_SECONDS):
+            raise TimeoutError("Speech recognition authorization request timed out")
+        if status_box[0] != SFSpeechRecognizerAuthorizationStatusAuthorized:
+            raise RuntimeError(
+                f"Speech recognition not authorized (status={status_box[0]}). "
+                "Approve at System Settings > Privacy & Security > Speech Recognition."
+            )
+
+    def _build_recognizer(self, locale: str):
+        ns_locale = NSLocale.alloc().initWithLocaleIdentifier_(locale)
+        recognizer = SFSpeechRecognizer.alloc().initWithLocale_(ns_locale)
+        if recognizer is None:
+            raise ValueError(f"Unsupported locale: {locale}")
+        if not recognizer.supportsOnDeviceRecognition():
+            raise RuntimeError(f"On-device recognition unavailable for locale {locale}")
+        if not recognizer.isAvailable():
+            raise RuntimeError("SFSpeechRecognizer not available right now")
+        return recognizer
+
+    def transcribe(self, audio) -> tuple[str, float]:
+        wav_bytes = prepare_wav_bytes(audio)
+        fd, temp_path = tempfile.mkstemp(suffix=".wav", dir=self.temp_dir)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(wav_bytes)
+
+            url = NSURL.fileURLWithPath_(temp_path)
+            request = SFSpeechURLRecognitionRequest.alloc().initWithURL_(url)
+            request.setRequiresOnDeviceRecognition_(True)
+            request.setShouldReportPartialResults_(False)
+
+            done_event = threading.Event()
+            text_box = [""]
+            error_box = [None]
+
+            def handler(result, error):
+                if error is not None:
+                    error_box[0] = str(error)
+                    done_event.set()
+                    return
+                if result is None:
+                    return
+                if result.isFinal():
+                    text_box[0] = str(result.bestTranscription().formattedString())
+                    done_event.set()
+
+            start = time.time()
+            task = self.recognizer.recognitionTaskWithRequest_resultHandler_(
+                request, handler
+            )
+
+            if not _pump_run_loop_until(done_event, self.TRANSCRIBE_TIMEOUT_SECONDS):
+                task.cancel()
+                raise RuntimeError(
+                    f"Recognition timed out after {self.TRANSCRIBE_TIMEOUT_SECONDS}s"
+                )
+            elapsed = time.time() - start
+
+            if error_box[0]:
+                raise RuntimeError(f"SFSpeechRecognizer error: {error_box[0]}")
+            return text_box[0], elapsed
+        finally:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+    def close(self) -> None:
+        if getattr(self, "temp_dir", None):
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+            self.temp_dir = None

--- a/tests/test_eval_apple_speech.py
+++ b/tests/test_eval_apple_speech.py
@@ -1,0 +1,143 @@
+"""Tests for AppleSpeechEvaluator."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_AUTHORIZED = 3
+_DENIED = 1
+
+
+@pytest.fixture
+def fake_speech_frameworks(monkeypatch):
+    """Inject fake Speech / Foundation / CoreFoundation modules so tests run on
+    Linux CI without pyobjc-framework-Speech installed."""
+    fake_speech = MagicMock(name="Speech")
+    fake_speech.SFSpeechRecognizerAuthorizationStatusAuthorized = _AUTHORIZED
+    fake_speech.SFSpeechRecognizer.requestAuthorization_.side_effect = (
+        lambda cb: cb(_AUTHORIZED)
+    )
+
+    recognizer = MagicMock(name="SFSpeechRecognizer-instance")
+    recognizer.supportsOnDeviceRecognition.return_value = True
+    recognizer.isAvailable.return_value = True
+    fake_speech.SFSpeechRecognizer.alloc.return_value.initWithLocale_.return_value = (
+        recognizer
+    )
+
+    fake_corefoundation = MagicMock(name="CoreFoundation")
+    fake_corefoundation.CFRunLoopRunInMode.return_value = 0
+    fake_corefoundation.kCFRunLoopDefaultMode = "kCFRunLoopDefaultMode"
+
+    monkeypatch.setitem(sys.modules, "Speech", fake_speech)
+    monkeypatch.setitem(sys.modules, "Foundation", MagicMock(name="Foundation"))
+    monkeypatch.setitem(sys.modules, "CoreFoundation", fake_corefoundation)
+
+    # Reload asr.py so module-level imports pick up the fakes.
+    import importlib
+
+    from scripts.eval.evaluators import asr
+
+    importlib.reload(asr)
+
+    return {"Speech": fake_speech, "recognizer": recognizer, "asr": asr}
+
+
+def _stage_transcription(recognizer, *, text="hello world", error=None):
+    def fake_task(_request, handler):
+        if error is not None:
+            handler(None, error)
+        else:
+            result = MagicMock()
+            result.isFinal.return_value = True
+            transcription = MagicMock()
+            transcription.formattedString.return_value = text
+            result.bestTranscription.return_value = transcription
+            handler(result, None)
+        return MagicMock()
+
+    recognizer.recognitionTaskWithRequest_resultHandler_.side_effect = fake_task
+
+
+class TestAppleSpeechEvaluator:
+    def test_init_authorizes_and_builds_recognizer(self, fake_speech_frameworks):
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator(locale="en-US")
+        assert ev.locale == "en-US"
+        assert ev.recognizer is fake_speech_frameworks["recognizer"]
+
+    def test_authorization_denied_raises(self, fake_speech_frameworks):
+        fake_speech_frameworks["Speech"].SFSpeechRecognizer.requestAuthorization_.side_effect = (
+            lambda cb: cb(_DENIED)
+        )
+        with pytest.raises(RuntimeError, match="not authorized"):
+            fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+
+    def test_unsupported_locale_raises(self, fake_speech_frameworks):
+        fake_speech_frameworks["Speech"].SFSpeechRecognizer.alloc.return_value.initWithLocale_.return_value = None
+        with pytest.raises(ValueError, match="Unsupported locale"):
+            fake_speech_frameworks["asr"].AppleSpeechEvaluator(locale="zz-ZZ")
+
+    def test_on_device_unsupported_raises(self, fake_speech_frameworks):
+        fake_speech_frameworks["recognizer"].supportsOnDeviceRecognition.return_value = False
+        with pytest.raises(RuntimeError, match="On-device recognition unavailable"):
+            fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+
+    def test_num_workers_gt_1_warns_and_downgrades(self, fake_speech_frameworks):
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator(num_workers=4)
+        assert ev.num_workers == 1
+
+    def test_transcribe_returns_text_and_elapsed(self, fake_speech_frameworks, mocker):
+        mocker.patch.object(
+            fake_speech_frameworks["asr"], "prepare_wav_bytes", return_value=b"WAVDATA"
+        )
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+        _stage_transcription(ev.recognizer, text="hello world")
+
+        text, elapsed = ev.transcribe(audio={"array": [], "sampling_rate": 16000})
+
+        assert text == "hello world"
+        assert elapsed >= 0
+
+    def test_transcribe_propagates_error(self, fake_speech_frameworks, mocker):
+        mocker.patch.object(
+            fake_speech_frameworks["asr"], "prepare_wav_bytes", return_value=b"WAVDATA"
+        )
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+        _stage_transcription(ev.recognizer, error="audio too long")
+
+        with pytest.raises(RuntimeError, match="audio too long"):
+            ev.transcribe(audio={"array": [], "sampling_rate": 16000})
+
+    def test_transcribe_cleans_up_temp_wav(self, fake_speech_frameworks, mocker):
+        import os
+
+        mocker.patch.object(
+            fake_speech_frameworks["asr"], "prepare_wav_bytes", return_value=b"WAVDATA"
+        )
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+        _stage_transcription(ev.recognizer)
+
+        before = set(os.listdir(ev.temp_dir))
+        ev.transcribe(audio={"array": [], "sampling_rate": 16000})
+        after = set(os.listdir(ev.temp_dir))
+
+        assert before == after, f"temp wav not cleaned up: {after - before}"
+
+    def test_close_removes_temp_dir(self, fake_speech_frameworks):
+        import os
+
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+        temp_dir = ev.temp_dir
+        assert os.path.isdir(temp_dir)
+
+        ev.close()
+
+        assert ev.temp_dir is None
+        assert not os.path.exists(temp_dir)
+
+    def test_close_idempotent(self, fake_speech_frameworks):
+        ev = fake_speech_frameworks["asr"].AppleSpeechEvaluator()
+        ev.close()
+        ev.close()


### PR DESCRIPTION
Adds `apple-speech` to `ta eval` — Apple's on-device SFSpeechRecognizer via PyObjC. macOS-only via sys_platform marker (mirrors the bitsandbytes Linux pattern). 17.26% WER on Loquacious n=1000.