### PR TITLE
Remove dead code

### DIFF
--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -747,57 +747,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
 
         thread.join()
 
-    @torch.no_grad()
-    def generate_text_only(
-        self,
-        messages: list[dict[str, str]],
-        max_new_tokens: int = 256,
-        **generate_kwargs,
-    ) -> str:
-        """Generate text using only the LLM (no audio encoding).
-
-        Used for SIFT-style response generation from metadata prompts.
-
-        Args:
-            messages: List of chat messages [{"role": "user", "content": "..."}]
-            max_new_tokens: Maximum tokens to generate
-            **generate_kwargs: Additional generation arguments
-
-        Returns:
-            Generated text response
-        """
-        device = next(self.language_model.parameters()).device
-
-        # Apply chat template
-        input_ids = self.tokenizer.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=True,
-            return_tensors="pt",
-            enable_thinking=False,  # Disable Qwen3 thinking mode for ASR
-        ).to(device)
-
-        if input_ids.dim() == 1:
-            input_ids = input_ids.unsqueeze(0)
-
-        attention_mask = torch.ones_like(input_ids)
-
-        # Generate using language model directly
-        output = self.language_model.generate(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            max_new_tokens=max_new_tokens,
-            do_sample=False,
-            pad_token_id=self.tokenizer.pad_token_id,
-            eos_token_id=self.tokenizer.eos_token_id,
-            **generate_kwargs,
-        )
-
-        # Decode only the new tokens
-        new_tokens = output[0, input_ids.shape[1] :]
-        response = self.tokenizer.decode(new_tokens, skip_special_tokens=True)
-        return response.strip()
-
     def save_pretrained(self, save_directory: Union[str, Path], **kwargs) -> None:
         """Save model, tokenizer, and processor."""
         import shutil
@@ -895,10 +844,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
         self.config.pretrained_model_path = repo_id
         # Call parent's push_to_hub
         return super().push_to_hub(repo_id, **kwargs)
-
-    def create_or_update_model_card(self, output_dir: Union[str, Path]) -> None:
-        """No-op for model card creation - we use MODEL_CARD.md in repo instead."""
-        pass
 
 
 # Register with transformers Auto classes

--- a/tiny_audio/projectors.py
+++ b/tiny_audio/projectors.py
@@ -89,34 +89,6 @@ class SimpleAdapter(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
-class SwiGLU(nn.Module):
-    """SwiGLU activation with gated linear units (used in LLaMA, Mistral, etc.)."""
-
-    def __init__(self, dim: int, hidden_dim: int, bias: bool = False):
-        super().__init__()
-        self.w1 = nn.Linear(dim, hidden_dim, bias=bias)  # Gate
-        self.w2 = nn.Linear(dim, hidden_dim, bias=bias)  # Value
-        self.w3 = nn.Linear(hidden_dim, dim, bias=bias)  # Output
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w3(F.silu(self.w1(x)) * self.w2(x))
-
-
-class AsymmetricSwiGLU(nn.Module):
-    """SwiGLU that handles different input and output dimensions."""
-
-    def __init__(
-        self, in_features: int, hidden_features: int, out_features: int, bias: bool = False
-    ):
-        super().__init__()
-        self.w1 = nn.Linear(in_features, hidden_features, bias=bias)  # Gate
-        self.w2 = nn.Linear(in_features, hidden_features, bias=bias)  # Value
-        self.w3 = nn.Linear(hidden_features, out_features, bias=bias)  # Output
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w3(F.silu(self.w1(x)) * self.w2(x))
-
-
 class MOSAProjector(nn.Module):
     """MOSA-Base projector: simple 2-layer ReLU router with 4 simple adapters.
 


### PR DESCRIPTION
## Summary
Drops orphaned classes/methods flagged by vulture and verified to have no callers anywhere in the codebase or tests:

- `SwiGLU` and `AsymmetricSwiGLU` classes in `tiny_audio/projectors.py` — never imported or instantiated by any projector.
- `ASRModel.generate_text_only` in `tiny_audio/asr_modeling.py` — docstring claims "used for SIFT", but the SIFT dataset generator (`scripts/generate_sift_dataset.py`) runs LLM generation independently and does not call this method.
- `ASRModel.create_or_update_model_card` in `tiny_audio/asr_modeling.py` — no-op stub that wasn't on any HF parent class and was never invoked.

83 lines removed across 2 files.

The remaining vulture finding (`num_items_in_batch` in `ASRTrainer.compute_loss`) is a false positive — required for HF Trainer signature compatibility.

## Test plan
- [x] `poetry run pytest tests/ -v` → 283/283 pass
- [x] `poetry run ta dev dead-code` → only the known-false-positive `num_items_in_batch` remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)