### PR TITLE
Simplify tiny_audio package

### DIFF
--- a/tests/test_asr_processing.py
+++ b/tests/test_asr_processing.py
@@ -13,10 +13,10 @@ class TestComputeEncoderOutputLength:
     @pytest.fixture
     def processor_method(self):
         """Get the method without creating full processor."""
-        from tiny_audio.asr_processing import ASRProcessor
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
 
         class MockProcessor:
-            encoder_conv_layers = ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+            encoder_conv_layers = DEFAULT_ENCODER_CONV_LAYERS
 
             def _compute_encoder_output_length(self, mel_length: int) -> int:
                 length = mel_length
@@ -64,10 +64,10 @@ class TestProcessorConstants:
 
     def test_default_conv_layers(self):
         """DEFAULT_ENCODER_CONV_LAYERS should match Whisper."""
-        from tiny_audio.asr_processing import ASRProcessor
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
 
         expected = [(1, 3, 1), (1, 3, 2)]
-        assert expected == ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+        assert expected == DEFAULT_ENCODER_CONV_LAYERS
 
 
 class TestProcessorInit:
@@ -88,11 +88,12 @@ class TestProcessorInit:
         self, mock_feature_extractor, mock_tokenizer, mock_projector
     ):
         """Should use default conv layers when not specified."""
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
         from tiny_audio.asr_processing import ASRProcessor
 
         processor = ASRProcessor(mock_feature_extractor, mock_tokenizer, mock_projector)
 
-        assert processor.encoder_conv_layers == ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+        assert processor.encoder_conv_layers == DEFAULT_ENCODER_CONV_LAYERS
 
     def test_init_accepts_custom_conv_layers(
         self, mock_feature_extractor, mock_tokenizer, mock_projector

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -4,35 +4,6 @@ import pytest
 import torch
 
 
-class TestIsFlashAttnAvailable:
-    """Tests for EndpointHandler._is_flash_attn_available."""
-
-    def test_returns_bool(self):
-        """Should return a boolean."""
-        from tiny_audio.handler import EndpointHandler
-
-        handler = object.__new__(EndpointHandler)
-        result = handler._is_flash_attn_available()
-
-        assert isinstance(result, bool)
-
-    def test_checks_flash_attn_module(self, mocker):
-        """Should check for flash_attn module."""
-        from tiny_audio.handler import EndpointHandler
-
-        handler = object.__new__(EndpointHandler)
-        mock_find = mocker.patch("importlib.util.find_spec")
-
-        # Test when flash_attn is available
-        mock_find.return_value = True
-        assert handler._is_flash_attn_available() is True
-        mock_find.assert_called_with("flash_attn")
-
-        # Test when flash_attn is not available
-        mock_find.return_value = None
-        assert handler._is_flash_attn_available() is False
-
-
 class TestEndpointHandlerCall:
     """Tests for EndpointHandler.__call__ method."""
 

--- a/tiny_audio/alignment.py
+++ b/tiny_audio/alignment.py
@@ -120,15 +120,18 @@ class ForcedAligner:
 
             if move_score >= stay_score:
                 # Token j-1 was emitted at frame t-1
-                token_frames[j - 1].insert(0, t - 1)
+                token_frames[j - 1].append(t - 1)
                 j -= 1
-            # Always decrement time (monotonic)
             t -= 1
 
         # Handle any remaining tokens at the start (edge case)
         while j > 0:
-            token_frames[j - 1].insert(0, 0)
+            token_frames[j - 1].append(0)
             j -= 1
+
+        # We appended in reverse-time order; restore monotonic order
+        for frames in token_frames:
+            frames.reverse()
 
         # Convert to spans
         token_spans: list[tuple[int, float, float]] = []

--- a/tiny_audio/asr_config.py
+++ b/tiny_audio/asr_config.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import transformers
 
+# Default conv layers for Whisper/GLM-ASR audio encoders: [(pad, kernel, stride), ...]
+DEFAULT_ENCODER_CONV_LAYERS = [(1, 3, 1), (1, 3, 2)]
+
 
 class ASRConfig(transformers.PretrainedConfig):
     """Configuration class for the ASR model.
@@ -107,8 +110,7 @@ class ASRConfig(transformers.PretrainedConfig):
         self.system_prompt = system_prompt
         self.encoder_dim = encoder_dim
         self.llm_dim = llm_dim
-        # Default conv layers for Whisper/GLM-ASR: [(pad, kernel, stride), ...]
-        self.encoder_conv_layers = encoder_conv_layers or [(1, 3, 1), (1, 3, 2)]
+        self.encoder_conv_layers = encoder_conv_layers or DEFAULT_ENCODER_CONV_LAYERS
         self.audio_sample_rate = audio_sample_rate
         self.projector_init_std = projector_init_std
         self.projector_pool_stride = projector_pool_stride
@@ -151,28 +153,18 @@ class ASRConfig(transformers.PretrainedConfig):
         ]
         self.freeze_projector = freeze_projector
 
-        # Generation parameters (use explicit value if provided, else use default)
-        self.num_beams = num_beams if num_beams is not None else generation_defaults["num_beams"]
-        self.max_new_tokens = (
-            max_new_tokens if max_new_tokens is not None else generation_defaults["max_new_tokens"]
-        )
-        self.min_new_tokens = (
-            min_new_tokens if min_new_tokens is not None else generation_defaults["min_new_tokens"]
-        )
-        self.repetition_penalty = (
-            repetition_penalty
-            if repetition_penalty is not None
-            else generation_defaults["repetition_penalty"]
-        )
-        self.length_penalty = (
-            length_penalty if length_penalty is not None else generation_defaults["length_penalty"]
-        )
-        self.no_repeat_ngram_size = (
-            no_repeat_ngram_size
-            if no_repeat_ngram_size is not None
-            else generation_defaults["no_repeat_ngram_size"]
-        )
-        self.use_cache = use_cache if use_cache is not None else generation_defaults["use_cache"]
+        explicit_generation_args = {
+            "num_beams": num_beams,
+            "max_new_tokens": max_new_tokens,
+            "min_new_tokens": min_new_tokens,
+            "repetition_penalty": repetition_penalty,
+            "length_penalty": length_penalty,
+            "no_repeat_ngram_size": no_repeat_ngram_size,
+            "use_cache": use_cache,
+        }
+        for key, default in generation_defaults.items():
+            value = explicit_generation_args[key]
+            setattr(self, key, value if value is not None else default)
         self.do_sample = do_sample
         self.temperature = temperature
         self.top_p = top_p

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -6,7 +6,6 @@ from typing import Iterator, Optional, Union
 import torch
 import torch.nn as nn
 from transformers import (
-    AutoConfig,
     AutoModel,
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -482,8 +481,8 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             if self.training and self.spec_augment is not None:
                 input_features = self.spec_augment(input_features)
 
-            # Count expected audio tokens from input_ids (ground truth from collator)
-            audio_token_counts = (input_ids == self.audio_token_id).sum(dim=-1)
+            is_audio_token = input_ids == self.audio_token_id
+            audio_token_counts = is_audio_token.sum(dim=-1)
 
             # Encode audio -> flattened (total_audio_tokens, hidden_dim)
             audio_embeds = self._encode_audio(
@@ -491,7 +490,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             )
 
             # Replace <audio> token placeholders with audio embeddings using masked_scatter
-            audio_token_mask = (input_ids == self.audio_token_id).unsqueeze(-1)
+            audio_token_mask = is_audio_token.unsqueeze(-1)
             inputs_embeds = inputs_embeds.masked_scatter(
                 audio_token_mask.to(inputs_embeds.device),
                 audio_embeds.to(inputs_embeds.device, dtype=inputs_embeds.dtype),
@@ -750,9 +749,8 @@ class ASRModel(PreTrainedModel, GenerationMixin):
     def save_pretrained(self, save_directory: Union[str, Path], **kwargs) -> None:
         """Save model, tokenizer, and processor."""
         import shutil
-        from pathlib import Path as PathlibPath
 
-        save_dir = PathlibPath(save_directory)
+        save_dir = Path(save_directory)
         save_dir.mkdir(parents=True, exist_ok=True)
 
         # Update config with actual vocab size
@@ -823,7 +821,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             json.dump(processor_config, f, indent=2)
 
         # Copy source files for auto-loading
-        src_dir = PathlibPath(__file__).parent
+        src_dir = Path(__file__).parent
         for asr_file in src_dir.glob("asr_*.py"):
             shutil.copy(asr_file, save_dir / asr_file.name)
         # Copy projectors module
@@ -847,5 +845,5 @@ class ASRModel(PreTrainedModel, GenerationMixin):
 
 
 # Register with transformers Auto classes
-AutoConfig.register("asr_model", ASRConfig)
+# (AutoConfig.register is handled in asr_config.py at module load.)
 AutoModel.register(ASRConfig, ASRModel)

--- a/tiny_audio/asr_pipeline.py
+++ b/tiny_audio/asr_pipeline.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import torch
 import transformers
+from transformers.pipelines.audio_utils import ffmpeg_read
 
 try:
     from .alignment import ForcedAligner
@@ -19,6 +20,13 @@ except ImportError:
 
 # Re-export for backwards compatibility
 __all__ = ["ForcedAligner", "SpeakerDiarizer", "ASRPipeline"]
+
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>\s*", flags=re.DOTALL)
+_DEFAULT_MIN_REPEATS = 3
+_TRAILING_CHAR_RE = re.compile(r"(.)\1{" + str(_DEFAULT_MIN_REPEATS - 1) + r",}$")
+_TRAILING_WORD_RE = re.compile(
+    r"\b(\w+)(?:\s+\1){" + str(_DEFAULT_MIN_REPEATS - 1) + r",}\s*$", re.IGNORECASE
+)
 
 
 class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
@@ -152,8 +160,6 @@ class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
 
     def _extract_audio(self, inputs) -> dict | None:
         """Extract audio array from various input formats using HF utilities."""
-        from transformers.pipelines.audio_utils import ffmpeg_read
-
         if isinstance(inputs, dict):
             if "array" in inputs:
                 return {
@@ -257,8 +263,8 @@ class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
 
         text = self.tokenizer.decode(tokens, skip_special_tokens=True).strip()
         # Strip <think>...</think> tags (Qwen3 doesn't respect /no_think prompt)
-        text = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
-        # Truncate repetitions at end of text
+        if "<think>" in text:
+            text = _THINK_TAG_RE.sub("", text).strip()
         text = _truncate_repetitions(text)
         return {"text": text}
 
@@ -281,14 +287,16 @@ def _truncate_repetitions(text: str, min_repeats: int = 3) -> str:
     if not text:
         return text
 
-    # 1. Truncate repeated characters at end (e.g., "444444" -> "4")
-    char_pattern = re.compile(r"(.)\1{" + str(min_repeats - 1) + r",}$")
-    text = char_pattern.sub(r"\1", text)
+    if min_repeats == _DEFAULT_MIN_REPEATS:
+        char_pattern = _TRAILING_CHAR_RE
+        word_pattern = _TRAILING_WORD_RE
+    else:
+        char_pattern = re.compile(r"(.)\1{" + str(min_repeats - 1) + r",}$")
+        word_pattern = re.compile(
+            r"\b(\w+)(?:\s+\1){" + str(min_repeats - 1) + r",}\s*$", re.IGNORECASE
+        )
 
-    # 2. Truncate repeated words at end (e.g., "the the the" -> "the")
-    word_pattern = re.compile(
-        r"\b(\w+)(?:\s+\1){" + str(min_repeats - 1) + r",}\s*$", re.IGNORECASE
-    )
+    text = char_pattern.sub(r"\1", text)
     while word_pattern.search(text):
         text = word_pattern.sub(r"\1", text)
 

--- a/tiny_audio/asr_processing.py
+++ b/tiny_audio/asr_processing.py
@@ -5,9 +5,9 @@ import transformers
 from transformers import ProcessorMixin
 
 try:
-    from .asr_config import ASRConfig
+    from .asr_config import DEFAULT_ENCODER_CONV_LAYERS, ASRConfig
 except ImportError:
-    from asr_config import ASRConfig  # type: ignore[no-redef]
+    from asr_config import DEFAULT_ENCODER_CONV_LAYERS, ASRConfig  # type: ignore[no-redef]
 
 
 class ASRProcessor(ProcessorMixin):
@@ -18,8 +18,6 @@ class ASRProcessor(ProcessorMixin):
     tokenizer_class = "AutoTokenizer"
     AUDIO_TOKEN = "<audio>"
     TRANSCRIBE_PROMPT = ""
-    # Default conv layers for Whisper/GLM-ASR: [(pad, kernel, stride), ...]
-    DEFAULT_ENCODER_CONV_LAYERS = [(1, 3, 1), (1, 3, 2)]
 
     def __init__(
         self,
@@ -40,7 +38,7 @@ class ASRProcessor(ProcessorMixin):
         self.tokenizer = tokenizer
         self.audio_token_id = tokenizer.convert_tokens_to_ids(self.AUDIO_TOKEN)
         self.projector = projector
-        self.encoder_conv_layers = encoder_conv_layers or self.DEFAULT_ENCODER_CONV_LAYERS
+        self.encoder_conv_layers = encoder_conv_layers or DEFAULT_ENCODER_CONV_LAYERS
 
     def _compute_encoder_output_length(self, mel_length: int) -> int:
         """Compute encoder output length using conv layer formulas."""

--- a/tiny_audio/diarization.py
+++ b/tiny_audio/diarization.py
@@ -154,8 +154,6 @@ class SpeakerClusterer:
         Returns:
             Cluster labels of shape [N]
         """
-        import warnings
-
         if len(embeddings.shape) != 2:
             raise ValueError(f"Expected 2D array, got shape {embeddings.shape}")
 

--- a/tiny_audio/handler.py
+++ b/tiny_audio/handler.py
@@ -28,39 +28,29 @@ class EndpointHandler:
         import os
 
         import nltk
+        from transformers.utils import is_flash_attn_2_available
 
         nltk.download("punkt_tab", quiet=True)
 
         os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
-        # Prepare model kwargs - let transformers handle device placement
         model_kwargs = {
             "device_map": "auto",
             "torch_dtype": "auto",
             "low_cpu_mem_usage": True,
         }
-        if self._is_flash_attn_available():
+        if is_flash_attn_2_available():
             model_kwargs["attn_implementation"] = "flash_attention_2"
 
-        # Load model (this loads the model, tokenizer, and feature extractor)
         self.model = ASRModel.from_pretrained(path, **model_kwargs)
-
-        # Get device from model for pipeline
         self.device = next(self.model.parameters()).device
 
-        # Instantiate custom pipeline - it will get feature_extractor and tokenizer from model
         self.pipe = ASRPipeline(
             model=self.model,
             feature_extractor=self.model.feature_extractor,
             tokenizer=self.model.tokenizer,
             device=self.device,
         )
-
-    def _is_flash_attn_available(self):
-        """Check if flash attention is available."""
-        import importlib.util
-
-        return importlib.util.find_spec("flash_attn") is not None
 
     def __call__(self, data: Dict[str, Any]) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Process an inference request.

--- a/tiny_audio/integrations/pipecat_stt.py
+++ b/tiny_audio/integrations/pipecat_stt.py
@@ -3,6 +3,7 @@
 from typing import Optional
 
 import numpy as np
+import torch
 
 try:
     from pipecat.frames.frames import (
@@ -46,6 +47,7 @@ class TinyAudioSTTService(SegmentedSTTService):
     ):
         super().__init__(**kwargs)
         self._model = None
+        self._model_dtype: Optional[torch.dtype] = None
         self._model_id = model_id
         self._streaming = streaming
         self._device = device
@@ -53,8 +55,6 @@ class TinyAudioSTTService(SegmentedSTTService):
     def _ensure_model(self):
         """Lazy-load the model on first use."""
         if self._model is None:
-            import torch
-
             try:
                 from tiny_audio import ASRModel  # pyright: ignore[reportMissingImports]
             except ImportError:
@@ -76,10 +76,10 @@ class TinyAudioSTTService(SegmentedSTTService):
                 else:
                     self._device = torch.device("cpu")
 
-            # Load model and move to device
             self._model = ASRModel.from_pretrained(self._model_id)
             self._model.to(self._device)
             self._model.eval()
+            self._model_dtype = next(self._model.parameters()).dtype
 
     async def run_stt(self, audio: bytes):
         """Transcribe audio segment, yielding interim results if streaming enabled.
@@ -101,9 +101,6 @@ class TinyAudioSTTService(SegmentedSTTService):
             yield TranscriptionFrame(text="", user_id=self._user_id, timestamp="")
             return
 
-        # Preprocess audio through feature extractor
-        import torch
-
         inputs = self._model.feature_extractor(
             audio_array,
             sampling_rate=16000,
@@ -111,9 +108,7 @@ class TinyAudioSTTService(SegmentedSTTService):
             return_attention_mask=True,
         )
 
-        # Get model dtype and cast inputs to match
-        model_dtype = next(self._model.parameters()).dtype
-        input_features = inputs.input_features.to(self._device, dtype=model_dtype)
+        input_features = inputs.input_features.to(self._device, dtype=self._model_dtype)
         attention_mask = inputs.attention_mask.to(self._device)
 
         if self._streaming:

--- a/tiny_audio/projectors.py
+++ b/tiny_audio/projectors.py
@@ -58,13 +58,7 @@ class MLPAudioProjector(nn.Module):
         Returns:
             Projected features of shape [batch, (seq_len - k) // k + 1, llm_dim]
         """
-        batch, seq, dim = x.shape
-        # Truncate to match GLM-ASR: use (seq - k) // k + 1 frames
-        # This drops trailing frames that don't fill a complete k-frame window
-        out_len = (seq - self.k) // self.k + 1
-        x = x[:, : out_len * self.k, :]  # Truncate to exact multiple
-        x = x.reshape(batch, out_len, dim * self.k)
-
+        x = _frame_stack(x, self.k)
         x = self.linear_1(x)
         x = self.norm(x)
         x = self.act(x)
@@ -74,6 +68,17 @@ class MLPAudioProjector(nn.Module):
 # =============================================================================
 # MoE Projector (MOSA-style)
 # =============================================================================
+
+
+def _frame_stack(x: torch.Tensor, k: int) -> torch.Tensor:
+    """Stack k adjacent frames along the feature dim.
+
+    Truncates trailing frames that don't fill a complete k-frame window,
+    matching GLM-ASR's `(seq_len - k) // k + 1` formula.
+    """
+    batch, seq, dim = x.shape
+    out_len = (seq - k) // k + 1
+    return x[:, : out_len * k, :].reshape(batch, out_len, dim * k)
 
 
 class SimpleAdapter(nn.Module):
@@ -253,13 +258,10 @@ class MoEAudioProjector(nn.Module):
         Returns:
             Projected features of shape [batch, out_len, llm_dim]
         """
-        # 1. Frame Stacking
-        batch, seq, dim = x.shape
-        out_len = (seq - self.k) // self.k + 1
-        x = x[:, : out_len * self.k, :]
-        x = x.reshape(batch, out_len, dim * self.k)
+        x = _frame_stack(x, self.k)
+        batch, out_len, _ = x.shape
 
-        # 2. Normalize stacked input (like main branch SharedMoEBlock)
+        # Normalize stacked input (like main branch SharedMoEBlock)
         x = self.norm(x)
         flat_x = x.view(-1, x.size(-1))  # [tokens, in_dim]
 


### PR DESCRIPTION
## Summary
Behavior-preserving simplifications across all 11 files in `tiny_audio/`, surfaced by parallel code-reuse, code-quality, and efficiency reviews.

**Note:** This PR is stacked on top of #38 (\"Remove dead code\") — set base to `remove-dead-code`. Will need to be rebased onto `main` once #38 lands.

### Reuse / dedupe
- Lift `DEFAULT_ENCODER_CONV_LAYERS` into `asr_config.py` as a module-level constant; `asr_processing.py` imports it instead of redefining.
- Remove duplicate `AutoConfig.register(\"asr_model\", ASRConfig)` call from `asr_modeling.py` (kept in `asr_config.py`).
- Drop the redundant `PathlibPath` alias in `ASRModel.save_pretrained` — the module-level `Path` import is already in scope.
- Replace `handler._is_flash_attn_available` with `transformers.utils.is_flash_attn_2_available`.
- Extract `_frame_stack(x, k)` helper used by `MLPAudioProjector` and `MoEAudioProjector`.

### Quality
- Replace 7 copies of `x = x if x is not None else default[\"x\"]` in `ASRConfig.__init__` with a single dict-driven loop.
- Drop redundant inner `import warnings` in `SpeakerClusterer.__call__` (already imported at module top).
- Compute `(input_ids == self.audio_token_id)` once in `ASRModel.forward` instead of twice.

### Efficiency
- Hoist three regex patterns in `_truncate_repetitions` to module level (avoids `re.compile` per postprocess).
- Add `if \"<think>\" in text:` fast-path guard before the think-tag regex.
- Hoist `ffmpeg_read` import to module level in `asr_pipeline.py`.
- Hoist `import torch` out of `TinyAudioSTTService.run_stt` and cache `self._model_dtype` once at model load (was being re-fetched every audio segment in real-time streaming).
- Replace O(n²) `list.insert(0, ...)` in `alignment.py`'s Viterbi backtrack with append + single reverse.

### Skipped (out of scope for behavior-preserving simplify)
- Vectorizing per-sample loops in `_encode_audio` and the Viterbi trellis (numerics-sensitive).
- Unifying `_get_device` helpers across `alignment.py`, `diarization.py`, `pipecat_stt.py` — they have different priority orders (CUDA>MPS vs MPS>CUDA), so consolidation requires a behavior decision.
- God-method extraction in `ASRModel.__init__` / `from_pretrained` and `LocalSpeakerDiarizer._postprocess_segments`.
- Class-level mutable state in `ASRModel._is_loading_from_pretrained` — concurrency footgun, but fixing it requires restructuring.
- Comment cleanup — many \"narrating the obvious\" comments could go, but kept conservative to avoid bikeshedding.

### Stats
11 files changed, +77/-121 (-44 net).

## Test plan
- [x] `poetry run pytest tests/ -x --tb=short -q` → 281 pass (2 deleted with removed `_is_flash_attn_available` helper)
- [x] Pre-commit quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)