### PR TITLE
Simplify codebase: dedupe, dead code removal, behavior fixes

### DIFF
--- a/scripts/analysis.py
+++ b/scripts/analysis.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python3
-"""Analysis tools for ASR evaluation results.
+"""Analysis tools for ASR evaluation results."""
 
-Commands:
-    extract-entities - Extract named entities from reference texts for comparison
-    compare          - Generate comprehensive comparison tables for multiple models
-"""
-
-import contextlib
 import json
 import re
 from collections import defaultdict
@@ -22,10 +16,6 @@ app = typer.Typer(help="Analysis tools for ASR evaluation results")
 console = Console()
 
 KEYWORDS_FILE = "outputs/keywords.json"
-
-# =============================================================================
-# Shared utilities
-# =============================================================================
 
 
 def extract_dataset_name(dir_name: str) -> str:
@@ -102,11 +92,6 @@ def entity_itn_correct(entity_text: str, text: str) -> bool:
     entity_normalized = entity_lower.replace(":", ".").replace(",", "")
     text_normalized = text_lower.replace(":", ".").replace(",", "")
     return entity_normalized in text_normalized
-
-
-# =============================================================================
-# extract-entities command
-# =============================================================================
 
 
 @app.command("high-wer")
@@ -329,17 +314,13 @@ def extract_entities(
     }
 
     keywords_path = Path(KEYWORDS_FILE)
-    keywords_path.parent.mkdir(exist_ok=True)
+    keywords_path.parent.mkdir(parents=True, exist_ok=True)
     keywords_path.write_text(json.dumps(keywords, indent=2))
 
     console.print(f"\nExtracted entities from {len(all_references)} unique references")
     console.print(f"References with entities: {len(keywords['references'])}")
     console.print(f"Saved to [bold]{keywords_path}[/bold]")
 
-
-# =============================================================================
-# compare command - comprehensive model comparison
-# =============================================================================
 
 # Canonical dataset order for comparison tables
 DATASET_ORDER = [
@@ -383,22 +364,36 @@ DATASET_SHORT_NAMES = {
 }
 
 
+def parse_metrics_file(metrics_file: Path) -> dict:
+    """Parse a metrics.txt file into a dictionary."""
+    result = {}
+    for line in metrics_file.read_text().splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip().lower().replace(" ", "_")
+            value = value.strip()
+            try:
+                result[key] = float(value)
+            except ValueError:
+                result[key] = value
+    return result
+
+
 def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[str]) -> dict:
     """Collect all metrics for a model across datasets."""
     import jiwer
 
     model_dirs = find_model_dirs(outputs_dir, model_pattern, exclude, latest=True)
 
-    # Extract display name from folder structure
     display_name = extract_model_name(model_dirs[0].name) if model_dirs else model_pattern
 
     metrics = {
         "display_name": display_name,
         "datasets": {},
-        "by_length": defaultdict(lambda: {"samples": [], "wers": []}),
+        "by_length": defaultdict(lambda: {"wers": []}),
         "diarization": None,
         "alignment": None,
-        "mcq": {},  # MCQ results keyed by dataset name (e.g., "mmau")
+        "mcq": {},
         "entity_errors": defaultdict(lambda: {"found": 0, "total": 0}),
         "itn_errors": defaultdict(lambda: {"correct": 0, "total": 0}),
     }
@@ -407,7 +402,6 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
     all_preds = []
     all_latencies = []
 
-    # Load keywords for entity analysis
     keywords_path = Path(KEYWORDS_FILE)
     ref_entities = {}
     if keywords_path.exists():
@@ -419,7 +413,6 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
         metrics_file = dir_path / "metrics.txt"
         dir_name = dir_path.name
 
-        # Check for diarization/alignment/mcq results (special handling)
         if dir_name.endswith("_diarization"):
             if metrics_file.exists():
                 metrics["diarization"] = parse_metrics_file(metrics_file)
@@ -441,25 +434,21 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
 
         ds_metrics = {"refs": [], "preds": [], "avg_time": None, "wer": None}
 
-        # Parse metrics.txt
         if metrics_file.exists():
-            for line in metrics_file.read_text().splitlines():
-                if line.startswith("avg_time:"):
-                    try:
-                        ds_metrics["avg_time"] = float(line.split(":")[1].strip())
-                        all_latencies.append(ds_metrics["avg_time"])
-                    except ValueError:
-                        pass
-                elif line.startswith("wer:"):
-                    with contextlib.suppress(ValueError):
-                        ds_metrics["wer"] = float(line.split(":")[1].strip())
+            parsed = parse_metrics_file(metrics_file)
+            avg_time = parsed.get("avg_time")
+            if isinstance(avg_time, float):
+                ds_metrics["avg_time"] = avg_time
+                all_latencies.append(avg_time)
+            wer = parsed.get("wer")
+            if isinstance(wer, float):
+                ds_metrics["wer"] = wer
 
-        # Parse results
         for sample in parse_results_file(results_file):
-            ref = normalize_text(sample["ground_truth"])
-            pred = normalize_text(sample["prediction"])
             gt_raw = sample["ground_truth"]
             pred_raw = sample["prediction"]
+            ref = normalize_text(gt_raw)
+            pred = normalize_text(pred_raw)
 
             if ref:
                 ds_metrics["refs"].append(ref)
@@ -467,31 +456,23 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
                 all_refs.append(ref)
                 all_preds.append(pred)
 
-                # Track by word count
                 word_count = len(ref.split())
-                wer = sample.get("wer", 0)
-                metrics["by_length"][word_count]["samples"].append(sample)
-                metrics["by_length"][word_count]["wers"].append(wer)
+                metrics["by_length"][word_count]["wers"].append(sample.get("wer", 0))
 
-                # Track entity errors and ITN errors
                 if gt_raw in ref_entities:
                     for entity in ref_entities[gt_raw]:
                         entity_type = entity["label"]
                         entity_text = entity["text"]
 
-                        # Entity detection (normalized)
-                        found = entity_in_text(entity_text, pred_raw)
                         metrics["entity_errors"][entity_type]["total"] += 1
-                        if found:
+                        if entity_in_text(entity_text, pred_raw):
                             metrics["entity_errors"][entity_type]["found"] += 1
 
-                        # ITN accuracy (format preservation)
                         if entity_type in ITN_ENTITY_TYPES:
                             metrics["itn_errors"][entity_type]["total"] += 1
                             if entity_itn_correct(entity_text, pred_raw):
                                 metrics["itn_errors"][entity_type]["correct"] += 1
 
-        # Calculate detailed error breakdown
         if ds_metrics["refs"]:
             output = jiwer.process_words(ds_metrics["refs"], ds_metrics["preds"])
             total = output.hits + output.substitutions + output.deletions
@@ -505,7 +486,6 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
 
         metrics["datasets"][dataset] = ds_metrics
 
-    # Calculate corpus-level metrics
     if all_refs:
         output = jiwer.process_words(all_refs, all_preds)
         total = output.hits + output.substitutions + output.deletions
@@ -519,21 +499,6 @@ def collect_model_metrics(model_pattern: str, outputs_dir: Path, exclude: list[s
         metrics["avg_latency"] = sum(all_latencies) / len(all_latencies)
 
     return metrics
-
-
-def parse_metrics_file(metrics_file: Path) -> dict:
-    """Parse a metrics.txt file into a dictionary."""
-    result = {}
-    for line in metrics_file.read_text().splitlines():
-        if ":" in line:
-            key, value = line.split(":", 1)
-            key = key.strip().lower().replace(" ", "_")
-            value = value.strip()
-            try:
-                result[key] = float(value)
-            except ValueError:
-                result[key] = value
-    return result
 
 
 def _sort_key(value: str) -> float:
@@ -589,11 +554,11 @@ def compare(
         display_name = data.get("display_name", model)
         row = [display_name]
         avg_lat = data.get("avg_latency")
-        row.append(f"{avg_lat * 1000:.0f}" if avg_lat else "-")
+        row.append(f"{avg_lat * 1000:.0f}" if avg_lat is not None else "-")
         for ds in ordered_datasets:
             ds_data = data["datasets"].get(ds, {})
             lat = ds_data.get("avg_time")
-            row.append(f"{lat * 1000:.0f}" if lat else "-")
+            row.append(f"{lat * 1000:.0f}" if lat is not None else "-")
         rows.append(row)
 
     for row in sorted(rows, key=lambda r: _sort_key(r[1])):
@@ -614,11 +579,13 @@ def compare(
         display_name = data.get("display_name", model)
         row = [display_name]
         corpus_wer = data.get("corpus_wer")
-        row.append(f"{corpus_wer:.2f}%" if corpus_wer else "-")
+        row.append(f"{corpus_wer:.2f}%" if corpus_wer is not None else "-")
         for ds in ordered_datasets:
             ds_data = data["datasets"].get(ds, {})
-            wer = ds_data.get("wer_calculated") or ds_data.get("wer")
-            row.append(f"{wer:.2f}%" if wer else "-")
+            wer = ds_data.get("wer_calculated")
+            if wer is None:
+                wer = ds_data.get("wer")
+            row.append(f"{wer:.2f}%" if wer is not None else "-")
         rows.append(row)
 
     for row in sorted(rows, key=lambda r: _sort_key(r[1])):
@@ -639,11 +606,11 @@ def compare(
         display_name = data.get("display_name", model)
         row = [display_name]
         avg_ins = data.get("corpus_ins_rate")
-        row.append(f"{avg_ins:.2f}%" if avg_ins else "-")
+        row.append(f"{avg_ins:.2f}%" if avg_ins is not None else "-")
         for ds in ordered_datasets:
             ds_data = data["datasets"].get(ds, {})
             ins = ds_data.get("ins_rate")
-            row.append(f"{ins:.2f}%" if ins else "-")
+            row.append(f"{ins:.2f}%" if ins is not None else "-")
         rows.append(row)
 
     for row in sorted(rows, key=lambda r: _sort_key(r[1])):

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,20 +1,5 @@
 #!/usr/bin/env python3
-"""Unified CLI for Tiny Audio.
-
-Usage:
-    tiny-audio <command> [options]
-    ta <command> [options]  # Short alias
-
-Commands:
-    eval        Evaluate ASR models on datasets
-    analysis    WER analysis and comparison tools
-    runpod      Remote training on RunPod
-    deploy      Deploy demo to HuggingFace Space
-    push        Push model to HuggingFace Hub
-    debug       Debug and analysis tools
-    demo        Launch Gradio demo
-    dev         Development commands (lint, test, format, etc.)
-"""
+"""Unified CLI for Tiny Audio."""
 
 import typer
 
@@ -27,48 +12,25 @@ app = typer.Typer(
 
 def register_subcommands():
     """Register all subcommand groups."""
-    # Eval
-    from scripts.eval.cli import app as eval_app
-
-    app.add_typer(eval_app, name="eval", help="Evaluate ASR models on datasets")
-
-    # Analysis
+    from demo.app import app as demo_app
     from scripts.analysis import app as analysis_app
-
-    app.add_typer(analysis_app, name="analysis", help="WER analysis and comparison tools")
-
-    # RunPod (top-level for remote training)
-    from scripts.deploy.runpod import app as runpod_app
-
-    app.add_typer(runpod_app, name="runpod", help="Remote training on RunPod")
-
-    # Deploy (direct command for HF Space)
+    from scripts.debug.cli import app as debug_app
     from scripts.deploy.hf_space import deploy as hf_deploy
-
-    app.command(name="deploy", help="Deploy demo to HuggingFace Space")(hf_deploy)
-
-    # Push (direct command for HF Hub)
+    from scripts.deploy.runpod import app as runpod_app
+    from scripts.dev import app as dev_app
+    from scripts.eval.cli import app as eval_app
     from scripts.hub.push import main as push_command
 
+    app.add_typer(eval_app, name="eval", help="Evaluate ASR models on datasets")
+    app.add_typer(analysis_app, name="analysis", help="WER analysis and comparison tools")
+    app.add_typer(runpod_app, name="runpod", help="Remote training on RunPod")
+    app.command(name="deploy", help="Deploy demo to HuggingFace Space")(hf_deploy)
     app.command(name="push", help="Push model to HuggingFace Hub")(push_command)
-
-    # Debug
-    from scripts.debug.cli import app as debug_app
-
     app.add_typer(debug_app, name="debug", help="Debug and analysis tools")
-
-    # Demo
-    from demo.app import app as demo_app
-
     app.add_typer(demo_app, name="demo", help="Launch Gradio demo")
-
-    # Dev
-    from scripts.dev import app as dev_app
-
     app.add_typer(dev_app, name="dev", help="Development commands")
 
 
-# Register subcommands at import time
 register_subcommands()
 
 if __name__ == "__main__":

--- a/scripts/debug/analyze_lora.py
+++ b/scripts/debug/analyze_lora.py
@@ -13,6 +13,22 @@ from safetensors.torch import load_file
 app = typer.Typer(help="Analyze LoRA adapter weights")
 console = Console()
 
+LORA_MODULE_TYPES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+
+
+def _section(title: str) -> None:
+    console.print("\n" + "=" * 80)
+    console.print(f"[bold]{title}[/bold]")
+    console.print("=" * 80)
+
 
 def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
     """Download and analyze LoRA adapter weights."""
@@ -23,11 +39,8 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
     console.print(f"Loading weights from {adapter_path}...")
     state_dict = load_file(adapter_path)
 
-    # Group by module type (q_proj, k_proj, etc.)
     module_stats = defaultdict(
         lambda: {
-            "A_norms": [],
-            "B_norms": [],
             "combined_norms": [],
             "ranks": [],
             "effective_ranks": [],
@@ -36,49 +49,21 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
         }
     )
 
-    # Parse tensor names and compute stats
-    lora_pairs = {}  # Map base name to (A, B) tensors
-
+    lora_pairs: dict[str, dict] = {}
     for name, tensor in state_dict.items():
-        # Extract module type from name like "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"
-        parts = name.split(".")
-
-        # Find module type (q_proj, k_proj, etc.)
-        module_type = None
-        for part in parts:
-            if part in [
-                "q_proj",
-                "k_proj",
-                "v_proj",
-                "o_proj",
-                "gate_proj",
-                "up_proj",
-                "down_proj",
-            ]:
-                module_type = part
-                break
-
+        module_type = next((p for p in name.split(".") if p in LORA_MODULE_TYPES), None)
         if module_type is None:
             continue
+        for ab in ("A", "B"):
+            marker = f".lora_{ab}.weight"
+            if marker in name:
+                base_name = name.replace(marker, "")
+                pair = lora_pairs.setdefault(base_name, {})
+                pair[ab] = tensor
+                pair["module_type"] = module_type
+                break
 
-        # Determine if this is lora_A or lora_B
-        if "lora_A" in name:
-            base_name = name.replace(".lora_A.weight", "")
-            if base_name not in lora_pairs:
-                lora_pairs[base_name] = {}
-            lora_pairs[base_name]["A"] = tensor
-            lora_pairs[base_name]["module_type"] = module_type
-        elif "lora_B" in name:
-            base_name = name.replace(".lora_B.weight", "")
-            if base_name not in lora_pairs:
-                lora_pairs[base_name] = {}
-            lora_pairs[base_name]["B"] = tensor
-            lora_pairs[base_name]["module_type"] = module_type
-
-    # Analyze each LoRA pair
-    console.print("\n" + "=" * 80)
-    console.print("[bold]PER-LAYER ANALYSIS[/bold]")
-    console.print("=" * 80)
+    _section("PER-LAYER ANALYSIS")
 
     total_params = 0
     all_effective_ratios = []
@@ -87,56 +72,40 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
         if "A" not in pair or "B" not in pair:
             continue
 
-        A = pair["A"].float()  # Shape: (rank, in_features)
-        B = pair["B"].float()  # Shape: (out_features, rank)
+        A = pair["A"].float()
+        B = pair["B"].float()
         module_type = pair["module_type"]
 
         rank = A.shape[0]
-
-        # Compute norms
-        A_norm = torch.norm(A).item()
-        B_norm = torch.norm(B).item()
-
-        # Compute combined weight matrix W = B @ A
         W = B @ A
         W_norm = torch.norm(W).item()
 
-        # Compute effective rank via SVD
         _, S, _ = torch.linalg.svd(W, full_matrices=False)
-
-        # Only look at top `rank` singular values (the rest are numerical noise)
+        # Top-`rank` singular values are signal; the rest is numerical noise.
         S_topk = S[:rank]
 
-        # Effective rank via entropy-based measure (more informative than threshold)
-        # Normalized singular values as probability distribution
+        # Effective rank as exp(entropy of normalized singular values).
         S_norm = S_topk / S_topk.sum()
         entropy = -(S_norm * torch.log(S_norm + 1e-10)).sum().item()
-        # Effective rank: exp(entropy), normalized to [0, 1]
         effective_rank = torch.exp(torch.tensor(entropy)).item()
         rank_utilization = effective_rank / rank if rank > 0 else 0
 
-        # Also compute how much energy is in top half vs bottom half of rank
         top_half_energy = (S_topk[: rank // 2] ** 2).sum().item()
         total_energy = (S_topk**2).sum().item()
         energy_concentration = top_half_energy / total_energy if total_energy > 0 else 0
 
         all_effective_ratios.append(rank_utilization)
 
-        # Store stats
         params = A.numel() + B.numel()
         total_params += params
-        module_stats[module_type]["A_norms"].append(A_norm)
-        module_stats[module_type]["B_norms"].append(B_norm)
-        module_stats[module_type]["combined_norms"].append(W_norm)
-        module_stats[module_type]["ranks"].append(rank)
-        module_stats[module_type]["effective_ranks"].append(effective_rank)
-        module_stats[module_type]["energy_concentrations"].append(energy_concentration)
-        module_stats[module_type]["params"] += params
+        stats = module_stats[module_type]
+        stats["combined_norms"].append(W_norm)
+        stats["ranks"].append(rank)
+        stats["effective_ranks"].append(effective_rank)
+        stats["energy_concentrations"].append(energy_concentration)
+        stats["params"] += params
 
-    # Print summary by module type
-    console.print("\n" + "=" * 80)
-    console.print("[bold]SUMMARY BY MODULE TYPE[/bold]")
-    console.print("=" * 80)
+    _section("SUMMARY BY MODULE TYPE")
     console.print(
         f"\n{'Module':<12} {'Count':>6} {'Params':>10} {'Avg Norm':>12} {'Eff Rank':>10} {'Rank Util':>11} {'Top50% E':>10}"
     )
@@ -144,15 +113,7 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
 
     module_importance = []
 
-    for module_type in [
-        "q_proj",
-        "k_proj",
-        "v_proj",
-        "o_proj",
-        "gate_proj",
-        "up_proj",
-        "down_proj",
-    ]:
+    for module_type in LORA_MODULE_TYPES:
         stats = module_stats[module_type]
         if not stats["combined_norms"]:
             continue
@@ -165,7 +126,6 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
         rank_util = avg_eff_rank / avg_rank if avg_rank > 0 else 0
         avg_energy_conc = sum(stats["energy_concentrations"]) / count
 
-        # Norm per parameter (normalized importance)
         norm_per_param = avg_norm / (params / count) if params > 0 else 0
         module_importance.append(
             (module_type, avg_norm, norm_per_param, rank_util, avg_energy_conc)
@@ -175,7 +135,6 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
             f"{module_type:<12} {count:>6} {params:>10,} {avg_norm:>12.4f} {avg_eff_rank:>10.1f} {rank_util:>10.1%} {avg_energy_conc:>10.1%}"
         )
 
-    # Overall stats
     console.print("-" * 80)
     console.print(f"{'TOTAL':<12} {'':<6} {total_params:>10,}")
 
@@ -183,17 +142,13 @@ def analyze_lora_adapter(repo_id: str = "mazesmazes/tiny-audio"):
         sum(all_effective_ratios) / len(all_effective_ratios) if all_effective_ratios else 0
     )
 
-    # Recommendations
-    console.print("\n" + "=" * 80)
-    console.print("[bold]ANALYSIS & RECOMMENDATIONS[/bold]")
-    console.print("=" * 80)
+    _section("ANALYSIS & RECOMMENDATIONS")
 
-    # Sort by normalized importance
     module_importance.sort(key=lambda x: x[2], reverse=True)
 
     console.print("\nModule importance (by norm per parameter):")
     for module_type, _avg_norm, norm_per_param, _rank_util, _energy_conc in module_importance:
-        bar = "█" * int(norm_per_param * 1e6)  # Scale for visibility
+        bar = "█" * int(norm_per_param * 1e6)
         console.print(f"  {module_type:<12} {bar}")
 
     console.print(f"\nOverall effective rank utilization: {avg_rank_util:.1%}")

--- a/scripts/debug/analyze_weights.py
+++ b/scripts/debug/analyze_weights.py
@@ -18,6 +18,20 @@ app = typer.Typer(help="Analyze model weights for training health")
 console = Console()
 
 
+def _section(title: str, width: int = 70) -> None:
+    console.print("\n" + "=" * width)
+    console.print(f"[bold]{title}[/bold]")
+    console.print("=" * width)
+
+
+def _threshold_status(value: float, warn: float, high: float) -> str:
+    if value < warn:
+        return "✅ OK"
+    if value < high:
+        return "⚠️  WARNING"
+    return "❌ HIGH"
+
+
 def estimate_effective_rank(tensor: torch.Tensor, threshold: float = 0.99) -> tuple[int, int]:
     """Estimate effective rank of a weight matrix using SVD.
 
@@ -28,21 +42,17 @@ def estimate_effective_rank(tensor: torch.Tensor, threshold: float = 0.99) -> tu
         return (0, 0)
 
     t = tensor.float()
-    # Use randomized SVD for large matrices
     try:
         if min(t.shape) > 1000:
-            # Sample for very large matrices
             _, singular_values, _ = torch.svd_lowrank(t, q=min(500, min(t.shape)))
         else:
             _, singular_values, _ = torch.linalg.svd(t, full_matrices=False)
     except Exception:
         return (0, min(t.shape))
 
-    # Compute variance explained
     total_var = (singular_values**2).sum()
     cumvar = torch.cumsum(singular_values**2, dim=0) / total_var
 
-    # Find rank needed for threshold variance
     effective_rank = (cumvar < threshold).sum().item() + 1
     full_rank = min(t.shape)
 
@@ -166,29 +176,14 @@ def print_tensor_analysis(stats: dict, verbose: bool = False):
             bar = "█" * int(data["pct"] / 2)
             console.print(f"    |x| {key:15s}: {data['count']:>12,} ({data['pct']:>6.2f}%) {bar}")
 
-    # Health checks
     console.print("\n  🔍 Health Checks:")
     nan_status = "❌ CRITICAL" if stats["nan_count"] > 0 else "✅ OK"
     inf_status = "❌ CRITICAL" if stats["inf_count"] > 0 else "✅ OK"
-    zero_status = (
-        "✅ OK"
-        if stats["exact_zero_pct"] < 1
-        else ("⚠️  WARNING" if stats["exact_zero_pct"] < 10 else "❌ HIGH")
-    )
-    near_zero_status = (
-        "✅ OK"
-        if stats["near_zero_pct"] < 1
-        else ("⚠️  WARNING" if stats["near_zero_pct"] < 10 else "❌ HIGH")
-    )
-    large_status = (
-        "✅ OK"
-        if stats["large_pct"] < 5
-        else ("⚠️  WARNING" if stats["large_pct"] < 20 else "❌ HIGH")
-    )
+    zero_status = _threshold_status(stats["exact_zero_pct"], 1, 10)
+    near_zero_status = _threshold_status(stats["near_zero_pct"], 1, 10)
+    large_status = _threshold_status(stats["large_pct"], 5, 20)
     very_large_pct = 100 * stats["very_large_count"] / stats["numel"]
-    very_large_status = (
-        "✅ OK" if very_large_pct < 1 else ("⚠️  WARNING" if very_large_pct < 5 else "❌ HIGH")
-    )
+    very_large_status = _threshold_status(very_large_pct, 1, 5)
 
     console.print(f"    NaN values:        {stats['nan_count']:>12,} {nan_status}")
     console.print(f"    Inf values:        {stats['inf_count']:>12,} {inf_status}")
@@ -280,11 +275,8 @@ def analyze_weights(
     verbose: bool = False,
 ):
     """Analyze model weights for training health."""
-    console.print("=" * 70)
-    console.print(f"[bold]Weight Analysis: {model_id}[/bold]")
-    console.print("=" * 70)
+    _section(f"Weight Analysis: {model_id}")
 
-    # Download model files
     try:
         config_path = hf_hub_download(repo_id=model_id, filename="config.json")
         weights_path = hf_hub_download(repo_id=model_id, filename="model.safetensors")
@@ -292,7 +284,6 @@ def analyze_weights(
         console.print(f"[red]Error downloading model: {e}[/red]")
         return False
 
-    # Load config
     with Path(config_path).open() as f:
         config = json.load(f)
 
@@ -312,10 +303,8 @@ def analyze_weights(
         if key in config:
             console.print(f"  {key}: {config[key]}")
 
-    # Load weights
     weights = load_file(weights_path)
 
-    # Filter weights if prefix specified
     if filter_prefix:
         weights = {k: v for k, v in weights.items() if filter_prefix in k}
         if not weights:
@@ -323,10 +312,7 @@ def analyze_weights(
             return False
         console.print(f"\nFiltering to weights containing '{filter_prefix}'")
 
-    # Print all tensors summary
-    console.print(f"\n{'=' * 70}")
-    console.print("[bold]WEIGHT TENSORS[/bold]")
-    console.print("=" * 70)
+    _section("WEIGHT TENSORS")
 
     total_params = 0
     trainable_params = 0
@@ -354,10 +340,7 @@ def analyze_weights(
     console.print(f"  Trainable parameters: {trainable_params:,}")
     console.print(f"  Frozen parameters:    {total_params - trainable_params:,}")
 
-    # Detailed analysis
-    console.print(f"\n{'=' * 70}")
-    console.print("[bold]DETAILED WEIGHT ANALYSIS[/bold]")
-    console.print("=" * 70)
+    _section("DETAILED WEIGHT ANALYSIS")
 
     all_stats = []
     for name in sorted(weights.keys()):
@@ -365,12 +348,8 @@ def analyze_weights(
         all_stats.append(stats)
         print_tensor_analysis(stats, verbose=verbose)
 
-    # Overall summary
-    console.print(f"\n{'=' * 70}")
-    console.print("[bold]OVERALL TRAINING HEALTH SUMMARY[/bold]")
-    console.print("=" * 70)
+    _section("OVERALL TRAINING HEALTH SUMMARY")
 
-    # Aggregate checks
     total_nans = sum(s["nan_count"] for s in all_stats)
     total_infs = sum(s["inf_count"] for s in all_stats)
     total_zeros = sum(s["exact_zero_count"] for s in all_stats)
@@ -396,10 +375,8 @@ def analyze_weights(
             f"     {short_name:25s}: mean={s['mean']:>10.6f}, std={s['std']:>8.6f}, range=[{s['min']:>8.4f}, {s['max']:>7.4f}]"
         )
 
-    # Training capacity analysis
     console.print("\n  📈 Training Capacity Analysis:")
 
-    # Collect rank utilization stats
     rank_stats = [
         (s["name"], s["effective_rank"], s["full_rank"], s["rank_utilization"])
         for s in all_stats
@@ -421,7 +398,6 @@ def analyze_weights(
             f"\n     Summary: avg={avg_rank_util:.1%}, min={min_rank_util:.1%}, max={max_rank_util:.1%}"
         )
 
-        # Interpret capacity
         if avg_rank_util < 0.4:
             capacity_status = "🟢 HIGH CAPACITY REMAINING"
             capacity_msg = "Model is using < 40% of its representational capacity. Significant room for continued training."
@@ -442,7 +418,6 @@ def analyze_weights(
         console.print(f"\n     {capacity_status}")
         console.print(f"     {capacity_msg}")
 
-    # Weight divergence from initialization
     xavier_ratios = [s["xavier_ratio"] for s in all_stats if "xavier_ratio" in s]
     if xavier_ratios:
         avg_xavier = sum(xavier_ratios) / len(xavier_ratios)
@@ -459,7 +434,6 @@ def analyze_weights(
         else:
             console.print("       ⚠️  Very high divergence - check for instability")
 
-    # Final verdict
     issues = []
     if total_nans > 0:
         issues.append("NaN values detected")

--- a/scripts/debug/check_moe.py
+++ b/scripts/debug/check_moe.py
@@ -17,14 +17,13 @@ from safetensors.torch import load_file
 app = typer.Typer(help="Check MoE model for router health")
 console = Console()
 
-# Target metrics for MoE with shared expert + sparse routed experts
 TARGETS = {
-    "entropy_min": 0.50,  # Minimum healthy entropy for routed experts
-    "entropy_max": 0.90,  # Maximum (above = uniform, not specialized)
-    "entropy_ideal": 0.70,  # Ideal entropy
-    "expert_min": 0.15,  # Minimum routed expert selection rate
-    "expert_max": 0.60,  # Maximum (one expert shouldn't dominate)
-    "load_balance_max": 0.3,  # Maximum load imbalance (std of expert usage)
+    "entropy_min": 0.50,
+    "entropy_max": 0.90,
+    "entropy_ideal": 0.70,
+    "expert_min": 0.15,
+    "expert_max": 0.60,
+    "load_balance_max": 0.3,
 }
 
 
@@ -64,7 +63,6 @@ def analyze_routing(probs, top_k_indices, num_experts, top_k, label=""):
         console.print(f"\n{label}")
         console.print("-" * 40)
 
-    # Sigmoid probabilities (before top-k)
     mean_probs = probs.mean(dim=0)
     std_probs = probs.std(dim=0)
 
@@ -76,15 +74,10 @@ def analyze_routing(probs, top_k_indices, num_experts, top_k, label=""):
         bar = "█" * int(mean_p * 40)
         console.print(f"  Expert {i}: {mean_p * 100:5.1f}% {std_p * 100:5.1f}%  {bar}")
 
-    # Top-k selection frequency
     console.print(f"\nTop-{top_k} Selection Frequency:")
-    selection_counts = torch.zeros(num_experts)
-    for k in range(top_k):
-        for expert_idx in range(num_experts):
-            selection_counts[expert_idx] += (top_k_indices[:, k] == expert_idx).sum().item()
-
+    selection_counts = torch.bincount(top_k_indices.flatten(), minlength=num_experts).float()
     total_selections = top_k_indices.numel()
-    selection_freq = selection_counts / total_selections * top_k  # Normalize to percentage
+    selection_freq = selection_counts / total_selections * top_k
 
     console.print(f"  {'Expert':<8} {'Selected':>10} {'Frequency':>10}  Distribution")
     console.print(f"  {'-' * 8} {'-' * 10} {'-' * 10}  {'-' * 20}")
@@ -93,7 +86,6 @@ def analyze_routing(probs, top_k_indices, num_experts, top_k, label=""):
         bar = "█" * int(freq * 40)
         console.print(f"  Expert {i}: {int(count):>10} {freq * 100:>8.1f}%  {bar}")
 
-    # Load balance analysis
     load_balance_std = selection_freq.std().item()
     ideal_freq = 1.0 / num_experts
     console.print("\nLoad Balance:")
@@ -104,7 +96,6 @@ def analyze_routing(probs, top_k_indices, num_experts, top_k, label=""):
     else:
         console.print("  -> Imbalanced (some experts over/under-used)")
 
-    # Entropy of selection (how uniform is top-k choice)
     selection_probs = selection_freq / selection_freq.sum()
     entropy = -(selection_probs * (selection_probs + 1e-10).log()).sum()
     max_entropy = torch.log(torch.tensor(float(num_experts)))
@@ -138,7 +129,6 @@ def check_moe(
     console.print(f"[bold]MoE Health Check: {model_id}[/bold]")
     console.print("=" * 80)
 
-    # Download latest model
     if force_download:
         cache_path = (
             Path.home() / ".cache/huggingface/hub" / f"models--{model_id.replace('/', '--')}"
@@ -152,7 +142,6 @@ def check_moe(
 
     weights = load_file(f"{path}/model.safetensors")
 
-    # Check if this is an MoE model
     router_key = "projector.moe.router.weight"
     if router_key not in weights:
         console.print("[red]ERROR: Router weight not found. Available keys:[/red]")
@@ -169,23 +158,19 @@ def check_moe(
     console.print(f"  Router input dim: {input_dim}")
     console.print(f"  Number of routed experts: {num_experts}")
 
-    # Check for shared expert
     shared_expert_key = "projector.moe.shared_expert.fc1.weight"
     has_shared_expert = shared_expert_key in weights
     console.print(f"  Has shared expert: {has_shared_expert}")
 
-    # Get top_k from config
     config_path = Path(path) / "config.json"
     with config_path.open() as f:
         config = json.load(f)
     top_k = config.get("num_experts_per_tok", 2)
     console.print(f"  Top-k routing: {top_k}")
 
-    # Download sample audio
     console.print()
     samples = download_sample_audio(num_samples)
 
-    # Get encoder model from config
     encoder_id = config.get("audio_model_id", "zai-org/GLM-ASR-Nano-2512")
 
     console.print(f"\nLoading encoder: {encoder_id}")
@@ -194,21 +179,17 @@ def check_moe(
 
     feature_extractor = AutoFeatureExtractor.from_pretrained(encoder_id, trust_remote_code=True)
 
-    # Get projector config
     pool_stride = config.get("projector_pool_stride", 4)
 
-    # Process all samples and collect routing data
     all_probs = []
     all_top_k_indices = []
     per_sample_stats = []
     model_dtype = next(encoder.parameters()).dtype
 
     for i, (audio, sr, _) in enumerate(samples):
-        # Resample to 16kHz if needed
         if sr != 16000:
             audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
 
-        # Get encoder outputs
         inputs = feature_extractor(audio, sampling_rate=16000, return_tensors="pt")
 
         with torch.no_grad():
@@ -222,24 +203,17 @@ def check_moe(
                 encoder_outputs = encoder(input_features)
             hidden_states = encoder_outputs.last_hidden_state
 
-        # Apply frame stacking (matches MoE projector)
         x = hidden_states.squeeze(0).float()
         seq_len = x.shape[0]
         out_len = (seq_len - pool_stride) // pool_stride + 1
-        x = x[: out_len * pool_stride, :]
-        x = x.reshape(out_len, -1)  # Frame stacking
+        x = x[: out_len * pool_stride, :].reshape(out_len, -1)
 
-        # Run through router (sigmoid routing)
         router_logits = functional.linear(x, router_weight)
         router_probs = torch.sigmoid(router_logits)
-
-        # Top-k selection
         _, top_k_indices = torch.topk(router_probs, top_k, dim=-1)
 
         all_probs.append(router_probs)
         all_top_k_indices.append(top_k_indices)
-
-        # Per-sample stats
         per_sample_stats.append(
             {
                 "sample_idx": i,
@@ -249,7 +223,6 @@ def check_moe(
             }
         )
 
-    # Concatenate all routing data
     probs = torch.cat(all_probs, dim=0)
     top_k_indices = torch.cat(all_top_k_indices, dim=0)
 
@@ -257,29 +230,22 @@ def check_moe(
         f"\nProcessed {len(samples)} samples, {probs.shape[0]} total tokens (after frame stacking)"
     )
 
-    # Analyze routing
     console.print(f"\n1. ROUTER BEHAVIOR ({len(samples)} sample(s), {probs.shape[0]} tokens)")
     selection_freq, entropy_ratio, load_balance_std = analyze_routing(
         probs, top_k_indices, num_experts, top_k
     )
 
-    # Show per-sample variation
     if len(samples) > 1:
         console.print("\nPer-sample top-k selection patterns (first 10 samples):")
         for stat in per_sample_stats[:10]:
-            # Count which experts are selected most often in this sample
             sample_selections = torch.tensor(stat["top_k_selection"])
-            sample_counts = torch.zeros(num_experts)
-            for k in range(top_k):
-                for expert_idx in range(num_experts):
-                    sample_counts[expert_idx] += (
-                        (sample_selections[:, k] == expert_idx).sum().item()
-                    )
+            sample_counts = torch.bincount(
+                sample_selections.flatten(), minlength=num_experts
+            ).float()
             sample_freq = sample_counts / sample_counts.sum()
             freq_str = " ".join([f"E{i}:{f * 100:.0f}%" for i, f in enumerate(sample_freq)])
             console.print(f"  Sample {stat['sample_idx']}: {freq_str}")
 
-    # Expert weight differentiation
     console.print("\n2. EXPERT DIFFERENTIATION")
     console.print("-" * 40)
 
@@ -315,7 +281,6 @@ def check_moe(
         else:
             console.print("[green]Good expert diversity[/green]")
 
-    # Check shared expert vs routed experts
     if has_shared_expert:
         console.print("\n3. SHARED EXPERT ANALYSIS")
         console.print("-" * 40)
@@ -329,14 +294,12 @@ def check_moe(
             sim = (shared_norm @ ew_norm).item()
             console.print(f"  Shared <-> Expert {i}: {sim:.4f}")
 
-    # Summary
     console.print("\n" + "=" * 80)
     console.print("[bold]SUMMARY[/bold]")
     console.print("=" * 80)
 
     issues = []
 
-    # Check for expert collapse
     min_selection = selection_freq.min().item()
     if min_selection < TARGETS["expert_min"]:
         issues.append(
@@ -363,7 +326,6 @@ def check_moe(
     else:
         console.print("[green]No issues detected.[/green]")
 
-    # MoE health summary
     console.print("\nMoE Health:")
     console.print(f"  Routed experts: {num_experts}")
     console.print(f"  Top-k: {top_k}")

--- a/scripts/debug/check_mosa.py
+++ b/scripts/debug/check_mosa.py
@@ -201,17 +201,15 @@ def check_mosa(
     # Use feature extractor (works for both Whisper and GLM-ASR)
     feature_extractor = AutoFeatureExtractor.from_pretrained(encoder_id, trust_remote_code=True)
 
-    # Process all samples and collect routing probabilities
     all_probs = []
+    all_logits = []
     per_sample_stats = []
     model_dtype = next(encoder.parameters()).dtype
 
     for i, (audio, sr, _text) in enumerate(samples):
-        # Resample to 16kHz if needed
         if sr != 16000:
             audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
 
-        # Get encoder outputs
         inputs = feature_extractor(audio, sampling_rate=16000, return_tensors="pt")
 
         with torch.no_grad():
@@ -225,29 +223,26 @@ def check_mosa(
                 encoder_outputs = encoder(input_features)
             hidden_states = encoder_outputs.last_hidden_state
 
-        # Run through router
         x_real = hidden_states.squeeze(0).float()
         logits = forward_router(x_real)
         probs = functional.softmax(logits, dim=-1)
+        all_logits.append(logits)
         all_probs.append(probs)
 
-        # Per-sample stats
-        mean_probs = probs.mean(dim=0)
         per_sample_stats.append(
             {
                 "sample_idx": i,
                 "num_tokens": probs.shape[0],
-                "expert_means": mean_probs.tolist(),
+                "expert_means": probs.mean(dim=0).tolist(),
                 "expert_stds": probs.std(dim=0).tolist(),
             }
         )
 
-    # Concatenate all routing probs across samples
     probs = torch.cat(all_probs, dim=0)
+    logits = torch.cat(all_logits, dim=0)
     console.print(f"\nProcessed {len(samples)} samples, {probs.shape[0]} total tokens")
     console.print(f"Router expects: {encoder_dim}-dim input, {num_experts} experts")
 
-    # Identify shared expert (highest mean usage) per MOSA architecture
     mean_probs_all = probs.mean(dim=0)
     shared_expert = mean_probs_all.argmax().item()
     specialist_experts = [i for i in range(num_experts) if i != shared_expert]
@@ -258,7 +253,6 @@ def check_mosa(
     )
     console.print(f"  Specialist experts: {specialist_experts}")
 
-    # Show per-sample variation if multiple samples
     if len(samples) > 1:
         console.print("\nPer-sample expert distribution (mean %):")
         header = f"  {'Sample':<8}"
@@ -266,7 +260,7 @@ def check_mosa(
             label = f"E{e}*" if e == shared_expert else f"E{e}"
             header += f" {label:>7}"
         console.print(header)
-        for stat in per_sample_stats[:10]:  # Show first 10
+        for stat in per_sample_stats[:10]:
             line = f"  {stat['sample_idx']:<8}"
             for m in stat["expert_means"]:
                 line += f"   {m * 100:5.1f}%"
@@ -274,7 +268,6 @@ def check_mosa(
         if len(per_sample_stats) > 10:
             console.print(f"  ... and {len(per_sample_stats) - 10} more samples")
 
-        # Cross-sample variance
         expert_means_per_sample = torch.tensor([s["expert_means"] for s in per_sample_stats])
         cross_sample_std = expert_means_per_sample.std(dim=0)
         console.print("\nCross-sample consistency (std of expert means across samples):")
@@ -282,7 +275,6 @@ def check_mosa(
             consistency = "consistent" if cross_sample_std[e] < 0.05 else "varies"
             console.print(f"  Expert {e}: {cross_sample_std[e] * 100:.1f}% std ({consistency})")
 
-    # Within-sample routing dynamics
     console.print("\nWithin-sample routing dynamics:")
     avg_within_sample_std = torch.tensor([s["expert_stds"] for s in per_sample_stats]).mean(dim=0)
     for e in range(num_experts):
@@ -295,10 +287,8 @@ def check_mosa(
                 f"  Expert {e} (specialist): {avg_within_sample_std[e] * 100:.1f}% avg std within samples"
             )
 
-    # Specialist activation analysis
     console.print("\nSpecialist expert activation:")
     for e in specialist_experts:
-        # When does this expert get > 25% routing weight?
         activation_rate = (probs[:, e] > 0.25).float().mean().item()
         peak_activation = probs[:, e].max().item()
         console.print(
@@ -308,25 +298,6 @@ def check_mosa(
     console.print(f"\n1. ROUTER BEHAVIOR ({len(samples)} sample(s), {probs.shape[0]} tokens)")
     console.print("-" * 40)
 
-    # Recompute logits stats from all samples
-    all_logits = []
-    for audio, sr, _ in samples:
-        if sr != 16000:
-            audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
-        inputs = feature_extractor(audio, sampling_rate=16000, return_tensors="pt")
-        with torch.no_grad():
-            input_features = inputs.input_features.to(model_dtype)
-            if hasattr(encoder, "encoder"):
-                encoder_outputs = encoder.encoder(input_features)
-            elif hasattr(encoder, "audio_tower"):
-                encoder_outputs = encoder.audio_tower(input_features)
-            else:
-                encoder_outputs = encoder(input_features)
-            hidden_states = encoder_outputs.last_hidden_state
-        x_real = hidden_states.squeeze(0).float()
-        all_logits.append(forward_router(x_real))
-    logits = torch.cat(all_logits, dim=0)
-
     console.print(f"Logit mean: {logits.mean():.4f}, std: {logits.std():.4f}")
     console.print(f"Logit range: [{logits.min():.4f}, {logits.max():.4f}]")
 
@@ -334,9 +305,8 @@ def check_mosa(
     if logit_exploded:
         console.print("[red]WARNING: Router logits have exploded![/red]")
 
-    max_prob, min_prob, dominant_expert, entropy_ratio = analyze_routing(probs, num_experts)
+    max_prob, _min_prob, _dominant_expert, entropy_ratio = analyze_routing(probs, num_experts)
 
-    # Expert differentiation
     console.print("\n2. EXPERT DIFFERENTIATION")
     console.print("-" * 40)
 
@@ -363,12 +333,10 @@ def check_mosa(
         if avg_sim > 0.5:
             console.print("[yellow]WARNING: Experts are converging (losing diversity)[/yellow]")
 
-    # Summary
     console.print("\n" + "=" * 80)
     console.print("[bold]SUMMARY[/bold]")
     console.print("=" * 80)
 
-    # Check for critical issues (MOSA-aware)
     issues = []
     if logit_exploded:
         issues.append("Router logits exploded (std > 100)")
@@ -382,7 +350,6 @@ def check_mosa(
     else:
         console.print("[green]No issues detected.[/green]")
 
-    # MOSA health summary
     console.print("\nMOSA Health:")
     console.print(f"  Shared expert (E{shared_expert}): {max_prob * 100:.1f}% avg routing")
     console.print(f"  Specialist experts: {[f'E{e}' for e in specialist_experts]}")

--- a/scripts/debug/cli.py
+++ b/scripts/debug/cli.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Debug and analysis CLI.
-
-Commands:
-    check-moe        Check MoE model for router health
-    check-mosa       Check MOSA model for router collapse
-    analyze-lora     Analyze LoRA adapter weights
-    analyze-weights  Analyze model weights for training health
-"""
+"""Debug and analysis CLI."""
 
 import typer
 

--- a/scripts/deploy/handler_local.py
+++ b/scripts/deploy/handler_local.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
-"""
-Local runner script to test the HuggingFace inference endpoint handler.
-This simulates the inference endpoint environment locally for debugging.
-"""
+"""Local runner to test the HuggingFace inference endpoint handler."""
 
 import json
 import sys
@@ -11,7 +8,6 @@ from pathlib import Path
 
 import typer
 
-# Try importing required modules
 try:
     from tiny_audio.handler import EndpointHandler
 except ImportError as e:
@@ -27,23 +23,16 @@ def find_latest_model(base_dir: str = "outputs") -> str | None:
     outputs_path = Path(base_dir)
     if not outputs_path.exists():
         return None
-
-    # Find all model.safetensors files
-    model_files = list(outputs_path.glob("**/model.safetensors"))
-
-    if not model_files:
-        return None
-
-    # Sort by modification time and get the most recent
-    model_files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-
-    # Return the parent directory of the model file
-    return str(model_files[0].parent)
+    model_files = sorted(
+        outputs_path.glob("**/model.safetensors"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return str(model_files[0].parent) if model_files else None
 
 
 def find_test_audio() -> str | None:
     """Find a test audio file in the project."""
-    # Look for test audio files in common locations
     test_paths = [
         ".venv/lib/python3.11/site-packages/gradio/test_data/test_audio.wav",
         ".venv/lib/python3.11/site-packages/gradio/media_assets/audio/cantina.wav",
@@ -58,8 +47,7 @@ def find_test_audio() -> str | None:
         if full_path.exists():
             return str(full_path)
 
-    # Try to find any audio file
-    for ext in ["*.wav", "*.mp3", "*.flac"]:
+    for ext in ("*.wav", "*.mp3", "*.flac"):
         audio_files = list(base_dir.glob(f"**/{ext}"))
         if audio_files:
             return str(audio_files[0])
@@ -108,34 +96,28 @@ def test(
     ),
 ):
     """Test the EndpointHandler with various configurations."""
-    # Determine model path
-    model_path = model
-    if model_path is None:
-        typer.echo("No model specified, using default HuggingFace Hub model...")
-        model_path = "mazesmazes/tiny-audio"
-        typer.echo(f"   Using model: {model_path}")
+    model_path = model or "mazesmazes/tiny-audio"
+    if model is None:
+        typer.echo(f"No model specified, using default: {model_path}")
 
     typer.echo("=" * 80)
     typer.echo("HuggingFace Inference Endpoint Handler - Local Test Runner")
     typer.echo("=" * 80)
 
-    # Step 1: Initialize the handler
     typer.echo(f"\nLoading model from: {model_path}")
     typer.echo("   This may take a moment on first load...")
 
     start_time = time.time()
     try:
         handler = EndpointHandler(path=model_path)
-        load_time = time.time() - start_time
-        typer.echo(f"Model loaded successfully in {load_time:.2f} seconds")
     except Exception as e:
         typer.echo(f"Failed to load model: {e}")
         import traceback
 
         traceback.print_exc()
         raise typer.Exit(1) from None
+    typer.echo(f"Model loaded successfully in {time.time() - start_time:.2f} seconds")
 
-    # Step 2: Find or use provided audio file
     audio_path = str(audio) if audio else None
     if audio_path is None:
         typer.echo("\nNo audio file specified, searching for test audio...")
@@ -152,82 +134,56 @@ def test(
         raise typer.Exit(1)
 
     typer.echo(f"\nUsing audio file: {audio_path}")
-
-    # Step 3: Prepare the request data
     typer.echo("\nPreparing inference request...")
 
-    # Basic single file test
+    params: dict = {
+        "max_new_tokens": max_new_tokens,
+        "num_beams": num_beams,
+        "do_sample": do_sample,
+    }
+    if do_sample:
+        params["temperature"] = temperature
+
     if not batch_test:
-        params = {
-            "max_new_tokens": max_new_tokens,
-            "num_beams": num_beams,
-            "do_sample": do_sample,
-        }
-        # Only add temperature when sampling is enabled
-        if do_sample:
-            params["temperature"] = temperature
-
-        data = {
-            "inputs": audio_path,
-            "parameters": params,
-        }
-
+        data = {"inputs": audio_path, "parameters": params}
         typer.echo(f"   Parameters: max_new_tokens={max_new_tokens}, num_beams={num_beams}")
         typer.echo(f"              temperature={temperature}, do_sample={do_sample}")
 
-        # Step 4: Run inference
         typer.echo("\nRunning transcription...")
         start_time = time.time()
         try:
             result = handler(data)
-            inference_time = time.time() - start_time
-            typer.echo(f"Inference completed in {inference_time:.2f} seconds")
-
-            # Step 5: Display results
-            typer.echo("\nTranscription Result:")
-            typer.echo("-" * 40)
-            if "text" in result:
-                typer.echo(result["text"])
-            else:
-                typer.echo(json.dumps(result, indent=2))
-            typer.echo("-" * 40)
-
         except Exception as e:
             typer.echo(f"Inference failed: {e}")
             import traceback
 
             traceback.print_exc()
+        else:
+            typer.echo(f"Inference completed in {time.time() - start_time:.2f} seconds")
+            typer.echo("\nTranscription Result:")
+            typer.echo("-" * 40)
+            typer.echo(result.get("text", json.dumps(result, indent=2)))
+            typer.echo("-" * 40)
 
-    # Batch test (if requested)
     if batch_test:
         typer.echo("\nTesting batch processing...")
-
-        # Create a batch of the same audio file
         batch_size = 3
-        params = {
-            "max_new_tokens": max_new_tokens,
-            "num_beams": num_beams,
-            "batch_size": batch_size,
-            "do_sample": do_sample,
-        }
-        # Only add temperature when sampling is enabled
-        if do_sample:
-            params["temperature"] = temperature
-
-        data = {
-            "inputs": [audio_path] * batch_size,
-            "parameters": params,
-        }
-
+        batch_params = {**params, "batch_size": batch_size}
+        data = {"inputs": [audio_path] * batch_size, "parameters": batch_params}
         typer.echo(f"   Batch size: {batch_size}")
 
         start_time = time.time()
         try:
             result = handler(data)
+        except Exception as e:
+            typer.echo(f"Batch inference failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+        else:
             inference_time = time.time() - start_time
             typer.echo(f"Batch inference completed in {inference_time:.2f} seconds")
             typer.echo(f"   Average time per sample: {inference_time / batch_size:.2f} seconds")
-
             typer.echo("\nBatch Results:")
             typer.echo("-" * 40)
             if "texts" in result:
@@ -237,19 +193,8 @@ def test(
                 typer.echo(json.dumps(result, indent=2))
             typer.echo("-" * 40)
 
-        except Exception as e:
-            typer.echo(f"Batch inference failed: {e}")
-            import traceback
-
-            traceback.print_exc()
-
     typer.echo("\nTest completed!")
     typer.echo("=" * 80)
-
-
-def main():
-    """Entry point for pyproject.toml scripts."""
-    app()
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/hf_space.py
+++ b/scripts/deploy/hf_space.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python3
-"""
-Deploy the demo application to a Hugging Face Space.
-
-This script uploads the demo files (app.py, requirements.txt, README.md)
-and optionally the wav_outputs directory to a Hugging Face Space.
-
-Usage:
-    poetry run deploy-hf
-    poetry run deploy-hf --repo-id YOUR_USERNAME/YOUR_SPACE
-    poetry run deploy-hf --delete-existing
-"""
+"""Deploy the demo application to a Hugging Face Space."""
 
 from pathlib import Path
 
@@ -53,7 +43,6 @@ def deploy(
     """Deploy demo files to a Hugging Face Space."""
     repo_id = extract_repo_id(repo_id)
 
-    # Validate demo directory
     if not demo_dir.exists():
         raise typer.BadParameter(f"Demo directory not found: {demo_dir}")
 
@@ -66,8 +55,6 @@ def deploy(
     typer.echo(f"Demo directory: {demo_dir.absolute()}")
 
     api = HfApi()
-
-    # Create Space if it doesn't exist
     try:
         api.repo_info(repo_id=repo_id, repo_type="space")
         typer.echo(f"Space '{repo_id}' exists, uploading files...")
@@ -80,7 +67,6 @@ def deploy(
             private=private,
         )
 
-    # Upload the demo folder
     typer.echo("\nUploading files...")
     upload_folder(
         folder_path=str(demo_dir),

--- a/scripts/deploy/runpod.py
+++ b/scripts/deploy/runpod.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""
-Unified CLI for RunPod operations.
-
-Consolidates deployment, training, evaluation, session management, and checkpoint discovery.
-
-Usage:
-    runpod deploy <host> <port>          # Deploy code to remote
-    runpod train <host> <port>           # Start training in tmux
-    runpod eval <host> <port> -m <model> # Run evaluation in tmux
-    runpod attach <host> <port>          # Attach to running session
-    runpod checkpoint <host> <port>      # Find latest checkpoint
-"""
+"""Unified CLI for RunPod operations."""
 
 import os
 import subprocess
@@ -26,11 +15,35 @@ from invoke import UnexpectedExit
 
 app = typer.Typer(help="RunPod remote operations CLI")
 
-# =============================================================================
-# SSH/Tmux Utilities
-# =============================================================================
-
 SSH_KEY_PATH = "~/.ssh/id_ed25519"
+
+
+def _auto_session_name(prefix: str) -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M")
+    return f"{prefix}_{timestamp}"
+
+
+def _start_remote_tmux_script(
+    conn: Connection,
+    host: str,
+    port: int,
+    session_name: str,
+    script_content: str,
+    script_path: str,
+    no_attach: bool,
+) -> None:
+    """Upload a script to /tmp, start it in a tmux session, optionally attach."""
+    conn.run(f"cat > {script_path} << 'EOF'\n{script_content}\nEOF", hide=True)
+    conn.run(f"chmod +x {script_path}", hide=True)
+    result = conn.run(f"tmux new-session -d -s {session_name} {script_path}", warn=True)
+    if not result.ok:
+        print(f"Failed to start tmux session: {result.stderr}")
+        sys.exit(1)
+    print(f"\nSession '{session_name}' started.")
+    print(f"To re-attach later: ssh -p {port} root@{host} -t 'tmux attach -t {session_name}'")
+    if not no_attach:
+        time.sleep(2)
+        attach_tmux_session(host, port, session_name)
 
 
 def get_connection(host: str, port: int) -> Connection:
@@ -108,10 +121,6 @@ def attach_tmux_session(host: str, port: int, session_name: str) -> None:
     subprocess.run(cmd, shell=True)
     print(f"\nDetached from session '{session_name}'.")
 
-
-# =============================================================================
-# Deploy Command
-# =============================================================================
 
 RSYNC_EXCLUDES = [
     "__pycache__",
@@ -266,11 +275,6 @@ def deploy(
     print(f"To connect: ssh -i ~/.ssh/id_ed25519 -p {port} root@{host}")
 
 
-# =============================================================================
-# Train Command
-# =============================================================================
-
-
 def build_training_script(
     experiment: str,
     hf_token: str,
@@ -349,16 +353,13 @@ def train(
     if not test_connection(conn):
         sys.exit(1)
 
-    # Generate session name if not provided
     if session_name is None:
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M")
-        session_name = f"train_{experiment}_{timestamp}"
+        session_name = _auto_session_name(f"train_{experiment}")
 
     if force:
         print(f"Killing existing session '{session_name}' if present...")
         kill_tmux_session(conn, session_name)
 
-    # Get environment variables
     hf_token = os.environ.get("HF_TOKEN", "")
     wandb_run_id = wandb_run_id or os.environ.get("WANDB_RUN_ID")
     wandb_resume = wandb_resume or os.environ.get("WANDB_RESUME")
@@ -366,37 +367,19 @@ def train(
     if not hf_token:
         print("Warning: HF_TOKEN environment variable not set.")
 
-    # Build and upload training script
-    script_content = build_training_script(
-        experiment, hf_token, wandb_run_id, wandb_resume, extra_args or []
-    )
-    script_path = f"/tmp/train_{session_name}.sh"
-
     print(f"\nStarting training session '{session_name}' with experiment '{experiment}'...")
     if extra_args:
         print(f"Extra args: {' '.join(extra_args)}")
 
-    # Write script to remote
-    conn.run(f"cat > {script_path} << 'EOF'\n{script_content}\nEOF", hide=True)
-    conn.run(f"chmod +x {script_path}", hide=True)
-
-    # Start tmux session
-    result = conn.run(f"tmux new-session -d -s {session_name} {script_path}", warn=True)
-    if not result.ok:
-        print(f"Failed to start tmux session: {result.stderr}")
-        sys.exit(1)
-
-    print(f"\nTraining started in session '{session_name}'.")
-    print(f"To re-attach later: ssh -p {port} root@{host} -t 'tmux attach -t {session_name}'")
-
-    if not no_attach:
-        time.sleep(2)
-        attach_tmux_session(host, port, session_name)
-
-
-# =============================================================================
-# Attach Command
-# =============================================================================
+    _start_remote_tmux_script(
+        conn,
+        host,
+        port,
+        session_name,
+        build_training_script(experiment, hf_token, wandb_run_id, wandb_resume, extra_args or []),
+        f"/tmp/train_{session_name}.sh",
+        no_attach,
+    )
 
 
 @app.command()
@@ -425,7 +408,6 @@ def attach(
                 print(f"  - {session}")
         return
 
-    # Auto-select session if not specified
     if not session_name:
         if not sessions:
             print("\nNo active tmux sessions found. Start a training session first.")
@@ -459,11 +441,6 @@ def attach(
             print(f"Session '{session_name}' not found or an error occurred.")
     else:
         attach_tmux_session(host, port, session_name)
-
-
-# =============================================================================
-# SIFT Dataset Generation Command
-# =============================================================================
 
 
 def build_sift_script(
@@ -551,25 +528,16 @@ def sift(
     if not test_connection(conn):
         sys.exit(1)
 
-    # Generate session name if not provided
     if session_name is None:
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M")
-        session_name = f"sift_{timestamp}"
+        session_name = _auto_session_name("sift")
 
     if force:
         print(f"Killing existing session '{session_name}' if present...")
         kill_tmux_session(conn, session_name)
 
-    # Get environment variables
     hf_token = os.environ.get("HF_TOKEN", "")
     if not hf_token:
         print("Warning: HF_TOKEN environment variable not set.")
-
-    # Build and upload script
-    script_content = build_sift_script(
-        hf_token, output_repo, batch_size, max_samples, use_compile, datasets
-    )
-    script_path = f"/tmp/sift_{session_name}.sh"
 
     print(f"\nStarting SIFT generation session '{session_name}'...")
     print(f"Output repo: {output_repo}")
@@ -581,27 +549,15 @@ def sift(
     if use_compile:
         print("Using torch.compile for faster inference")
 
-    # Write script to remote
-    conn.run(f"cat > {script_path} << 'EOF'\n{script_content}\nEOF", hide=True)
-    conn.run(f"chmod +x {script_path}", hide=True)
-
-    # Start tmux session
-    result = conn.run(f"tmux new-session -d -s {session_name} {script_path}", warn=True)
-    if not result.ok:
-        print(f"Failed to start tmux session: {result.stderr}")
-        sys.exit(1)
-
-    print(f"\nSIFT generation started in session '{session_name}'.")
-    print(f"To re-attach later: ssh -p {port} root@{host} -t 'tmux attach -t {session_name}'")
-
-    if not no_attach:
-        time.sleep(2)
-        attach_tmux_session(host, port, session_name)
-
-
-# =============================================================================
-# Eval Command
-# =============================================================================
+    _start_remote_tmux_script(
+        conn,
+        host,
+        port,
+        session_name,
+        build_sift_script(hf_token, output_repo, batch_size, max_samples, use_compile, datasets),
+        f"/tmp/sift_{session_name}.sh",
+        no_attach,
+    )
 
 
 def build_eval_script(
@@ -708,17 +664,14 @@ def eval(
     if not test_connection(conn):
         sys.exit(1)
 
-    # Generate session name if not provided
     if session_name is None:
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M")
         model_short = model.split("/")[-1] if "/" in model else model
-        session_name = f"eval_{model_short}_{timestamp}"
+        session_name = _auto_session_name(f"eval_{model_short}")
 
     if force:
         print(f"Killing existing session '{session_name}' if present...")
         kill_tmux_session(conn, session_name)
 
-    # Get environment variables
     hf_token = os.environ.get("HF_TOKEN", "")
     assemblyai_api_key = os.environ.get("ASSEMBLYAI_API_KEY", "")
 
@@ -729,23 +682,8 @@ def eval(
             "Warning: ASSEMBLYAI_API_KEY environment variable not set (required for assemblyai model)."
         )
 
-    # Default datasets
     if datasets is None:
         datasets = ["loquacious"]
-
-    # Build and upload script
-    script_content = build_eval_script(
-        hf_token,
-        model,
-        datasets,
-        max_samples,
-        assemblyai_api_key,
-        assemblyai_model,
-        num_workers,
-        streaming,
-        extra_args,
-    )
-    script_path = f"/tmp/eval_{session_name}.sh"
 
     print(f"\nStarting eval session '{session_name}'...")
     print(f"Model: {model}")
@@ -757,27 +695,25 @@ def eval(
     if streaming:
         print("Streaming mode enabled")
 
-    # Write script to remote
-    conn.run(f"cat > {script_path} << 'EOF'\n{script_content}\nEOF", hide=True)
-    conn.run(f"chmod +x {script_path}", hide=True)
-
-    # Start tmux session
-    result = conn.run(f"tmux new-session -d -s {session_name} {script_path}", warn=True)
-    if not result.ok:
-        print(f"Failed to start tmux session: {result.stderr}")
-        sys.exit(1)
-
-    print(f"\nEvaluation started in session '{session_name}'.")
-    print(f"To re-attach later: ssh -p {port} root@{host} -t 'tmux attach -t {session_name}'")
-
-    if not no_attach:
-        time.sleep(2)
-        attach_tmux_session(host, port, session_name)
-
-
-# =============================================================================
-# Checkpoint Command
-# =============================================================================
+    _start_remote_tmux_script(
+        conn,
+        host,
+        port,
+        session_name,
+        build_eval_script(
+            hf_token,
+            model,
+            datasets,
+            max_samples,
+            assemblyai_api_key,
+            assemblyai_model,
+            num_workers,
+            streaming,
+            extra_args,
+        ),
+        f"/tmp/eval_{session_name}.sh",
+        no_attach,
+    )
 
 
 @app.command()
@@ -807,16 +743,6 @@ def checkpoint(
     else:
         print("No checkpoints found", file=sys.stderr)
         raise typer.Exit(1)
-
-
-# =============================================================================
-# CLI Entry Point
-# =============================================================================
-
-
-def cli():
-    """Entry point for pyproject.toml scripts."""
-    app()
 
 
 if __name__ == "__main__":

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,23 +1,5 @@
 #!/usr/bin/env python3
-"""Development commands for tiny-audio.
-
-Commands:
-    lint         Run linters (Poetry + Python + YAML + TOML)
-    format       Format code with black, ruff, and mdformat
-    type-check   Run type checkers (mypy and pyright)
-    test         Run fast pytest tests (skips slow model-loading tests)
-    test-slow    Run only slow pytest tests
-    test-all     Run all pytest tests
-    coverage     Run tests with coverage report
-    check        Run all checks (lint + type-check + security + docstrings)
-    build        Build package (wheel and sdist)
-    precommit    Pre-commit quality gate
-    security     Run security checks with bandit
-    dead-code    Find dead/unused code with vulture
-    docstrings   Check docstring coverage with interrogate
-    install-hooks Install pre-commit hooks
-    handler      Test inference endpoint handler locally
-"""
+"""Development commands for tiny-audio."""
 
 import subprocess
 from pathlib import Path
@@ -31,6 +13,23 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
+
+CODE_PATHS = ["tiny_audio", "scripts", "tests"]
+LIB_PATH = "tiny_audio"
+
+LINT_COMMANDS = [
+    ["poetry", "check"],
+    ["ruff", "check", *CODE_PATHS],
+    ["yamllint", "configs/"],
+    ["taplo", "check", "pyproject.toml"],
+]
+TYPE_CHECK_COMMANDS = [
+    ["mypy", LIB_PATH],
+    ["pyright", LIB_PATH],
+]
+SECURITY_COMMAND = ["bandit", "-c", "pyproject.toml", "-r", "tiny_audio", "scripts", "-ll"]
+DOCSTRINGS_COMMAND = ["interrogate", LIB_PATH, "--fail-under", "50"]
+CHECK_COMMANDS = [*LINT_COMMANDS, *TYPE_CHECK_COMMANDS, SECURITY_COMMAND, DOCSTRINGS_COMMAND]
 
 
 def run(*args: str) -> int:
@@ -51,23 +50,16 @@ def run_all(*commands: list[str]) -> int:
 @app.command()
 def lint():
     """Run linters (Poetry + Python + YAML + TOML)."""
-    code = run_all(
-        ["poetry", "check"],
-        ["ruff", "check", "tiny_audio", "scripts", "tests"],
-        ["yamllint", "configs/"],
-        ["taplo", "check", "pyproject.toml"],
-    )
-    raise typer.Exit(code)
+    raise typer.Exit(run_all(*LINT_COMMANDS))
 
 
 @app.command("format")
 def format_code():
     """Format code with black, ruff, and mdformat."""
-    run("black", "tiny_audio", "scripts", "tests")
-    run("ruff", "format", "tiny_audio", "scripts", "tests")
-    run("ruff", "check", "--fix", "tiny_audio", "scripts", "tests")
+    run("black", *CODE_PATHS)
+    run("ruff", "format", *CODE_PATHS)
+    run("ruff", "check", "--fix", *CODE_PATHS)
 
-    # Format markdown files
     md_files = [
         str(f)
         for f in Path().rglob("*.md")
@@ -80,11 +72,7 @@ def format_code():
 @app.command("type-check")
 def type_check():
     """Run type checkers (mypy and pyright)."""
-    code = run_all(
-        ["mypy", "tiny_audio"],
-        ["pyright", "tiny_audio"],
-    )
-    raise typer.Exit(code)
+    raise typer.Exit(run_all(*TYPE_CHECK_COMMANDS))
 
 
 @app.command()
@@ -99,7 +87,7 @@ def coverage():
     raise typer.Exit(
         run(
             "pytest",
-            "--cov=tiny_audio",
+            f"--cov={LIB_PATH}",
             "--cov-report=term-missing",
             "--cov-report=html",
             "-v",
@@ -110,17 +98,7 @@ def coverage():
 @app.command()
 def check():
     """Run all checks (lint + type-check + security + docstrings)."""
-    code = run_all(
-        ["poetry", "check"],
-        ["ruff", "check", "tiny_audio", "scripts", "tests"],
-        ["yamllint", "configs/"],
-        ["taplo", "check", "pyproject.toml"],
-        ["mypy", "tiny_audio"],
-        ["pyright", "tiny_audio"],
-        ["bandit", "-c", "pyproject.toml", "-r", "tiny_audio", "scripts", "-ll"],
-        ["interrogate", "tiny_audio", "--fail-under", "50"],
-    )
-    raise typer.Exit(code)
+    raise typer.Exit(run_all(*CHECK_COMMANDS))
 
 
 @app.command()
@@ -132,23 +110,8 @@ def build():
 @app.command()
 def precommit():
     """Pre-commit quality gate (format, lint, type-check, security, docstrings, test, build)."""
-    # Format first (doesn't fail)
     format_code()
-
-    # Then run all checks
-    code = run_all(
-        ["poetry", "check"],
-        ["ruff", "check", "tiny_audio", "scripts", "tests"],
-        ["yamllint", "configs/"],
-        ["taplo", "check", "pyproject.toml"],
-        ["mypy", "tiny_audio"],
-        ["pyright", "tiny_audio"],
-        ["bandit", "-c", "pyproject.toml", "-r", "tiny_audio", "scripts", "-ll"],
-        ["interrogate", "tiny_audio", "--fail-under", "50"],
-        ["pytest", "-v"],
-        ["poetry", "build"],
-    )
-    raise typer.Exit(code)
+    raise typer.Exit(run_all(*CHECK_COMMANDS, ["pytest", "-v"], ["poetry", "build"]))
 
 
 @app.command("install-hooks")
@@ -160,7 +123,7 @@ def install_hooks():
 @app.command()
 def security():
     """Run security checks with bandit."""
-    raise typer.Exit(run("bandit", "-c", "pyproject.toml", "-r", "tiny_audio", "scripts", "-ll"))
+    raise typer.Exit(run(*SECURITY_COMMAND))
 
 
 @app.command("dead-code")
@@ -172,11 +135,10 @@ def dead_code():
 @app.command()
 def docstrings():
     """Check docstring coverage with interrogate."""
-    raise typer.Exit(run("interrogate", "tiny_audio", "-v", "--fail-under", "50"))
+    raise typer.Exit(run("interrogate", LIB_PATH, "-v", "--fail-under", "50"))
 
 
 def _register_handler():
-    """Register handler subcommand (lazy import)."""
     from scripts.deploy.handler_local import test as handler_test
 
     app.command(name="handler", help="Test inference endpoint handler locally")(handler_test)

--- a/scripts/eval/audio.py
+++ b/scripts/eval/audio.py
@@ -23,26 +23,26 @@ def audio_to_wav_bytes(audio_array: np.ndarray | torch.Tensor, sample_rate: int)
     return buffer.getvalue()
 
 
+def _read_path_to_wav(path: str) -> bytes:
+    audio_array, sample_rate = sf.read(path)
+    return audio_to_wav_bytes(audio_array, sample_rate)
+
+
 def prepare_wav_bytes(wav_data) -> bytes:
     """Convert various audio formats to WAV bytes."""
-    # Dict with array (most common HF datasets format)
     if isinstance(wav_data, dict):
         if "array" in wav_data and "sampling_rate" in wav_data:
             return audio_to_wav_bytes(wav_data["array"], wav_data["sampling_rate"])
         if "bytes" in wav_data:
             return wav_data["bytes"]
         if "path" in wav_data and wav_data["path"]:
-            audio_array, sample_rate = sf.read(wav_data["path"])
-            return audio_to_wav_bytes(audio_array, sample_rate)
+            return _read_path_to_wav(wav_data["path"])
 
-    # Audio object with array/sampling_rate attributes
     if hasattr(wav_data, "array") and hasattr(wav_data, "sampling_rate"):
         return audio_to_wav_bytes(wav_data.array, wav_data.sampling_rate)
 
-    # AudioDecoder - try to get path and load with soundfile
     if hasattr(wav_data, "path") and wav_data.path:
-        audio_array, sample_rate = sf.read(wav_data.path)
-        return audio_to_wav_bytes(audio_array, sample_rate)
+        return _read_path_to_wav(wav_data.path)
 
     raise ValueError(f"Unsupported audio format: {type(wav_data)}")
 
@@ -66,11 +66,15 @@ class TextNormalizer:
         tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny")
         self._normalizer = EnglishTextNormalizer(tokenizer.english_spelling_normalizer)
 
+    _SPELLING_FIXES = {
+        "okay": "ok",
+        "all right": "alright",
+        "kinda": "kind of",
+    }
+
     def normalize(self, text: str) -> str:
         """Normalize text for WER calculation."""
         text = self._normalizer(text)
-        # Normalize common spelling variants
-        text = text.replace("okay", "ok")
-        text = text.replace("all right", "alright")
-        text = text.replace("kinda", "kind of")
+        for src, dst in self._SPELLING_FIXES.items():
+            text = text.replace(src, dst)
         return re.sub(r"'s\b", " is", text)

--- a/scripts/eval/cli.py
+++ b/scripts/eval/cli.py
@@ -57,18 +57,71 @@ class AssemblyAIModel(str, Enum):
     nano = "nano"
 
 
-# Valid dataset choices
 VALID_DATASETS = ["all", "all-full"] + list(DATASET_REGISTRY.keys())
+
+API_KEY_ENV_VARS = {
+    "assemblyai": "ASSEMBLYAI_API_KEY",
+    "deepgram": "DEEPGRAM_API_KEY",
+    "elevenlabs": "ELEVENLABS_API_KEY",
+}
 
 
 def get_model_name(model_path: str) -> str:
-    """Extract model name from a HuggingFace model path.
-
-    Examples:
-        - mazesmazes/tiny-audio -> tiny-audio
-        - /path/to/checkpoint -> checkpoint
-    """
+    """Extract model name from a HuggingFace model path."""
     return model_path.rstrip("/").split("/")[-1]
+
+
+def _require_api_key(model: str) -> str:
+    env_var = API_KEY_ENV_VARS[model]
+    api_key = os.environ.get(env_var, "")
+    if not api_key:
+        console.print(f"[red]Error: {env_var} environment variable not set[/red]")
+        raise typer.Exit(1)
+    return api_key
+
+
+def _make_result_dir(
+    model_name: str, dataset_name: str, output_dir: str, suffix: str = ""
+) -> tuple[Path, str]:
+    """Create a timestamped result directory; return (path, timestamp)."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    safe_model_name = model_name.replace("/", "_")
+    name = f"{timestamp}_{safe_model_name}_{dataset_name}{suffix}"
+    result_dir = Path(output_dir) / name
+    result_dir.mkdir(parents=True, exist_ok=True)
+    return result_dir, timestamp
+
+
+def _write_metrics_header(f, model_name: str, dataset_name: str, timestamp: str, **extra) -> None:
+    f.write(f"Model: {model_name}\n")
+    f.write(f"Dataset: {dataset_name}\n")
+    for k, v in extra.items():
+        f.write(f"{k}: {v}\n")
+    f.write(f"Timestamp: {timestamp}\n")
+    f.write("-" * 40 + "\n")
+
+
+def _write_metric_kv(f, key: str, value) -> None:
+    if isinstance(value, float):
+        f.write(f"{key}: {value:.4f}\n")
+    else:
+        f.write(f"{key}: {value}\n")
+
+
+def _base_url_suffix(base_url: str | None) -> str:
+    if not base_url:
+        return ""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    host = parsed.netloc or parsed.path
+    if not host:
+        return ""
+    parts = host.split(".")
+    for part in parts:
+        if "sandbox" in part.lower():
+            return f"_{part}"
+    return f"_{parts[0]}"
 
 
 def save_results(
@@ -81,33 +134,11 @@ def save_results(
 ) -> Path:
     """Save evaluation results and metrics to a timestamped directory."""
     normalizer = TextNormalizer()
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    safe_model_name = model_name.replace("/", "_")
+    # base_url goes in the directory name (after model, before dataset) for traceability
+    safe_model_name = model_name.replace("/", "_") + _base_url_suffix(base_url)
+    result_dir, timestamp = _make_result_dir(safe_model_name, dataset_name, output_dir)
 
-    # Extract short identifier from base_url (e.g., "sandbox013" from the URL)
-    url_suffix = ""
-    if base_url:
-        # Extract hostname and create a short identifier
-        from urllib.parse import urlparse
-
-        parsed = urlparse(base_url)
-        host = parsed.netloc or parsed.path
-        # Extract meaningful part (e.g., "sandbox013" from "api.sandbox013.assemblyai-labs.com")
-        parts = host.split(".")
-        for part in parts:
-            if "sandbox" in part.lower():
-                url_suffix = f"_{part}"
-                break
-        if not url_suffix and host:
-            # Fallback: use first part of hostname
-            url_suffix = f"_{parts[0]}"
-
-    result_dir = Path(output_dir) / f"{timestamp}_{safe_model_name}{url_suffix}_{dataset_name}"
-    result_dir.mkdir(parents=True, exist_ok=True)
-
-    # Save detailed results
-    results_file = result_dir / "results.txt"
-    with results_file.open("w") as f:
+    with (result_dir / "results.txt").open("w") as f:
         for i, r in enumerate(results, 1):
             norm_pred = normalizer.normalize(r.prediction)
             norm_ref = normalizer.normalize(r.reference)
@@ -116,20 +147,11 @@ def save_results(
             f.write(f"Prediction: {norm_pred}\n")
             f.write("-" * 80 + "\n")
 
-    # Save summary metrics
-    metrics_file = result_dir / "metrics.txt"
-    with metrics_file.open("w") as f:
-        f.write(f"Model: {model_name}\n")
-        f.write(f"Dataset: {dataset_name}\n")
-        if base_url:
-            f.write(f"Base URL: {base_url}\n")
-        f.write(f"Timestamp: {timestamp}\n")
-        f.write("-" * 40 + "\n")
+    with (result_dir / "metrics.txt").open("w") as f:
+        extras = {"Base URL": base_url} if base_url else {}
+        _write_metrics_header(f, model_name, dataset_name, timestamp, **extras)
         for key, value in metrics.items():
-            if isinstance(value, float):
-                f.write(f"{key}: {value:.4f}\n")
-            else:
-                f.write(f"{key}: {value}\n")
+            _write_metric_kv(f, key, value)
 
     console.print(f"\nResults saved to: [bold]{result_dir}[/bold]")
     return result_dir
@@ -143,14 +165,9 @@ def save_diarization_results(
     output_dir: str = "outputs",
 ) -> Path:
     """Save diarization evaluation results and metrics."""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    safe_model_name = model_name.replace("/", "_")
-    result_dir = Path(output_dir) / f"{timestamp}_{safe_model_name}_{dataset_name}_diarization"
-    result_dir.mkdir(parents=True, exist_ok=True)
+    result_dir, timestamp = _make_result_dir(model_name, dataset_name, output_dir, "_diarization")
 
-    # Save detailed results
-    results_file = result_dir / "results.txt"
-    with results_file.open("w") as f:
+    with (result_dir / "results.txt").open("w") as f:
         for i, r in enumerate(results, 1):
             f.write(f"Sample {i}\n")
             f.write(f"  DER: {r.der:.2f}%\n")
@@ -161,18 +178,10 @@ def save_diarization_results(
             f.write(f"  Time: {r.time:.2f}s\n")
             f.write("-" * 80 + "\n")
 
-    # Save summary metrics
-    metrics_file = result_dir / "metrics.txt"
-    with metrics_file.open("w") as f:
-        f.write(f"Model: {model_name}\n")
-        f.write(f"Dataset: {dataset_name}\n")
-        f.write(f"Timestamp: {timestamp}\n")
-        f.write("-" * 40 + "\n")
+    with (result_dir / "metrics.txt").open("w") as f:
+        _write_metrics_header(f, model_name, dataset_name, timestamp)
         for key, value in metrics.items():
-            if isinstance(value, float):
-                f.write(f"{key}: {value:.4f}\n")
-            else:
-                f.write(f"{key}: {value}\n")
+            _write_metric_kv(f, key, value)
 
     console.print(f"\nResults saved to: [bold]{result_dir}[/bold]")
     return result_dir
@@ -186,14 +195,9 @@ def save_alignment_results(
     output_dir: str = "outputs",
 ) -> Path:
     """Save alignment evaluation results and metrics."""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    safe_model_name = model_name.replace("/", "_")
-    result_dir = Path(output_dir) / f"{timestamp}_{safe_model_name}_{dataset_name}_alignment"
-    result_dir.mkdir(parents=True, exist_ok=True)
+    result_dir, timestamp = _make_result_dir(model_name, dataset_name, output_dir, "_alignment")
 
-    # Save detailed results
-    results_file = result_dir / "results.txt"
-    with results_file.open("w") as f:
+    with (result_dir / "results.txt").open("w") as f:
         for i, r in enumerate(results, 1):
             f.write(f"Sample {i}\n")
             f.write(f"  Aligned: {r.num_aligned_words}/{r.num_ref_words} words\n")
@@ -211,18 +215,10 @@ def save_alignment_results(
             f.write(f"  Prediction: {r.predicted_text[:100]}...\n")
             f.write("-" * 80 + "\n")
 
-    # Save summary metrics
-    metrics_file = result_dir / "metrics.txt"
-    with metrics_file.open("w") as f:
-        f.write(f"Model: {model_name}\n")
-        f.write(f"Dataset: {dataset_name}\n")
-        f.write(f"Timestamp: {timestamp}\n")
-        f.write("-" * 40 + "\n")
+    with (result_dir / "metrics.txt").open("w") as f:
+        _write_metrics_header(f, model_name, dataset_name, timestamp)
         for key, value in metrics.items():
-            if isinstance(value, float):
-                f.write(f"{key}: {value:.4f}\n")
-            else:
-                f.write(f"{key}: {value}\n")
+            _write_metric_kv(f, key, value)
 
     console.print(f"\nResults saved to: [bold]{result_dir}[/bold]")
     return result_dir
@@ -286,14 +282,9 @@ def save_mcq_results(
     output_dir: str = "outputs",
 ) -> Path:
     """Save MCQ evaluation results and metrics."""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    safe_model_name = model_name.replace("/", "_")
-    result_dir = Path(output_dir) / f"{timestamp}_{safe_model_name}_{dataset_name}_mcq"
-    result_dir.mkdir(parents=True, exist_ok=True)
+    result_dir, timestamp = _make_result_dir(model_name, dataset_name, output_dir, "_mcq")
 
-    # Save detailed results
-    results_file = result_dir / "results.txt"
-    with results_file.open("w") as f:
+    with (result_dir / "results.txt").open("w") as f:
         for i, r in enumerate(results, 1):
             status = "✓" if r.correct else "✗"
             f.write(f"Sample {i} [{status}]\n")
@@ -306,13 +297,8 @@ def save_mcq_results(
             f.write(f"  Time: {r.time:.2f}s\n")
             f.write("-" * 80 + "\n")
 
-    # Save summary metrics
-    metrics_file = result_dir / "metrics.txt"
-    with metrics_file.open("w") as f:
-        f.write(f"Model: {model_name}\n")
-        f.write(f"Dataset: {dataset_name}\n")
-        f.write(f"Timestamp: {timestamp}\n")
-        f.write("-" * 40 + "\n")
+    with (result_dir / "metrics.txt").open("w") as f:
+        _write_metrics_header(f, model_name, dataset_name, timestamp)
         f.write(f"Accuracy: {metrics['accuracy']:.2f}%\n")
         f.write(f"Correct: {metrics['correct']}/{metrics['total']}\n")
         f.write(f"Avg Time: {metrics['avg_time']:.2f}s\n")
@@ -357,15 +343,10 @@ def save_classification_results(
     output_dir: str = "outputs",
 ) -> Path:
     """Save classification evaluation results and metrics."""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    safe_model_name = model_name.replace("/", "_")
     task = metrics.get("task", "classification")
-    result_dir = Path(output_dir) / f"{timestamp}_{safe_model_name}_{dataset_name}_{task}"
-    result_dir.mkdir(parents=True, exist_ok=True)
+    result_dir, timestamp = _make_result_dir(model_name, dataset_name, output_dir, f"_{task}")
 
-    # Save detailed results
-    results_file = result_dir / "results.txt"
-    with results_file.open("w") as f:
+    with (result_dir / "results.txt").open("w") as f:
         for i, r in enumerate(results, 1):
             status = "correct" if r.correct else "wrong"
             f.write(f"Sample {i} [{status}]\n")
@@ -375,14 +356,8 @@ def save_classification_results(
             f.write(f"  Time: {r.time:.2f}s\n")
             f.write("-" * 80 + "\n")
 
-    # Save summary metrics
-    metrics_file = result_dir / "metrics.txt"
-    with metrics_file.open("w") as f:
-        f.write(f"Model: {model_name}\n")
-        f.write(f"Dataset: {dataset_name}\n")
-        f.write(f"Task: {task}\n")
-        f.write(f"Timestamp: {timestamp}\n")
-        f.write("-" * 40 + "\n")
+    with (result_dir / "metrics.txt").open("w") as f:
+        _write_metrics_header(f, model_name, dataset_name, timestamp, Task=task)
         f.write(f"Accuracy: {metrics['accuracy']:.2f}%\n")
         f.write(f"Correct: {metrics['correct']}/{metrics['total']}\n")
         f.write(f"Avg Time: {metrics['avg_time']:.2f}s\n")
@@ -532,12 +507,7 @@ def main(
         if dataset_name in DIARIZATION_DATASETS:
             dataset = load_eval_dataset(dataset_name, actual_split, config, decode_audio=False)
             if model == "assemblyai":
-                api_key = os.environ.get("ASSEMBLYAI_API_KEY", "")
-                if not api_key:
-                    console.print(
-                        "[red]Error: ASSEMBLYAI_API_KEY environment variable not set[/red]"
-                    )
-                    raise typer.Exit(1)
+                api_key = _require_api_key("assemblyai")
                 model_id = assemblyai_model.value.replace("_", "-")
                 evaluator = AssemblyAIDiarizationEvaluator(
                     api_key=api_key,
@@ -549,10 +519,7 @@ def main(
                     num_workers=num_workers,
                 )
             elif model == "deepgram":
-                api_key = os.environ.get("DEEPGRAM_API_KEY", "")
-                if not api_key:
-                    console.print("[red]Error: DEEPGRAM_API_KEY environment variable not set[/red]")
-                    raise typer.Exit(1)
+                api_key = _require_api_key("deepgram")
                 model_id = "nova-3"
                 evaluator = DeepgramDiarizationEvaluator(
                     api_key=api_key,
@@ -563,12 +530,7 @@ def main(
                     num_workers=num_workers,
                 )
             elif model == "elevenlabs":
-                api_key = os.environ.get("ELEVENLABS_API_KEY", "")
-                if not api_key:
-                    console.print(
-                        "[red]Error: ELEVENLABS_API_KEY environment variable not set[/red]"
-                    )
-                    raise typer.Exit(1)
+                api_key = _require_api_key("elevenlabs")
                 model_id = "scribe-v2"
                 evaluator = ElevenLabsDiarizationEvaluator(
                     api_key=api_key,
@@ -603,12 +565,7 @@ def main(
             dataset = load_eval_dataset(dataset_name, actual_split, config)
 
             if model == "assemblyai":
-                api_key = os.environ.get("ASSEMBLYAI_API_KEY", "")
-                if not api_key:
-                    console.print(
-                        "[red]Error: ASSEMBLYAI_API_KEY environment variable not set[/red]"
-                    )
-                    raise typer.Exit(1)
+                api_key = _require_api_key("assemblyai")
                 model_id = assemblyai_model.value.replace("_", "-")
                 evaluator = AssemblyAIAlignmentEvaluator(
                     api_key=api_key,
@@ -619,10 +576,7 @@ def main(
                     verbose=verbose,
                 )
             elif model == "deepgram":
-                api_key = os.environ.get("DEEPGRAM_API_KEY", "")
-                if not api_key:
-                    console.print("[red]Error: DEEPGRAM_API_KEY environment variable not set[/red]")
-                    raise typer.Exit(1)
+                api_key = _require_api_key("deepgram")
                 model_id = "nova-3"
                 evaluator = DeepgramAlignmentEvaluator(
                     api_key=api_key,
@@ -632,12 +586,7 @@ def main(
                     verbose=verbose,
                 )
             elif model == "elevenlabs":
-                api_key = os.environ.get("ELEVENLABS_API_KEY", "")
-                if not api_key:
-                    console.print(
-                        "[red]Error: ELEVENLABS_API_KEY environment variable not set[/red]"
-                    )
-                    raise typer.Exit(1)
+                api_key = _require_api_key("elevenlabs")
                 model_id = "scribe-v2"
                 evaluator = ElevenLabsAlignmentEvaluator(
                     api_key=api_key,
@@ -670,12 +619,7 @@ def main(
             dataset = hf_load_dataset(cfg.path, split=actual_split, streaming=True)
 
             if model == "assemblyai":
-                api_key = os.environ.get("ASSEMBLYAI_API_KEY", "")
-                if not api_key:
-                    console.print(
-                        "[red]Error: ASSEMBLYAI_API_KEY environment variable not set[/red]"
-                    )
-                    raise typer.Exit(1)
+                api_key = _require_api_key("assemblyai")
                 model_id = assemblyai_model.value.replace("_", "-")
                 evaluator = AssemblyAIMMAUEvaluator(
                     api_key=api_key,
@@ -750,10 +694,7 @@ def main(
         dataset = load_eval_dataset(dataset_name, actual_split, config)
 
         if model == "assemblyai":
-            api_key = os.environ.get("ASSEMBLYAI_API_KEY", "")
-            if not api_key:
-                console.print("[red]Error: ASSEMBLYAI_API_KEY environment variable not set[/red]")
-                raise typer.Exit(1)
+            api_key = _require_api_key("assemblyai")
 
             if streaming:
                 model_id = "universal-streaming"
@@ -774,10 +715,7 @@ def main(
                     num_workers=num_workers,
                 )
         elif model == "deepgram":
-            api_key = os.environ.get("DEEPGRAM_API_KEY", "")
-            if not api_key:
-                console.print("[red]Error: DEEPGRAM_API_KEY environment variable not set[/red]")
-                raise typer.Exit(1)
+            api_key = _require_api_key("deepgram")
             model_id = "nova-3"
             evaluator = DeepgramEvaluator(
                 api_key=api_key,
@@ -786,10 +724,7 @@ def main(
                 num_workers=num_workers,
             )
         elif model == "elevenlabs":
-            api_key = os.environ.get("ELEVENLABS_API_KEY", "")
-            if not api_key:
-                console.print("[red]Error: ELEVENLABS_API_KEY environment variable not set[/red]")
-                raise typer.Exit(1)
+            api_key = _require_api_key("elevenlabs")
             model_id = "scribe-v2"
             evaluator = ElevenLabsEvaluator(
                 api_key=api_key,

--- a/scripts/eval/evaluators/asr.py
+++ b/scripts/eval/evaluators/asr.py
@@ -16,6 +16,26 @@ from scripts.eval.audio import prepare_wav_bytes
 
 from .base import Evaluator, console, setup_assemblyai
 
+
+def _extract_audio_16khz(audio):
+    """Return a (mono) audio array at 16kHz from any supported audio input."""
+    if isinstance(audio, dict) and "array" in audio:
+        audio_array = audio["array"]
+        sample_rate = audio.get("sampling_rate", 16000)
+    elif isinstance(audio, dict) and "raw" in audio:
+        audio_array = audio["raw"]
+        sample_rate = audio.get("sampling_rate", 16000)
+    else:
+        wav_bytes = prepare_wav_bytes(audio)
+        audio_array, sample_rate = sf.read(io.BytesIO(wav_bytes))
+
+    if sample_rate != 16000:
+        import librosa
+
+        audio_array = librosa.resample(audio_array, orig_sr=sample_rate, target_sr=16000)
+    return audio_array
+
+
 try:
     from CoreFoundation import CFRunLoopRunInMode, kCFRunLoopDefaultMode
     from Foundation import NSURL, NSLocale
@@ -33,21 +53,21 @@ except ImportError:
 def print_generation_config(model, model_path: str):
     """Print generation config in a visible format."""
     gen_config = model.generation_config
-    console.print(
-        "\n[bold cyan]═══════════════════════════════════════════════════════════════[/bold cyan]"
-    )
+    divider = "[bold cyan]" + "═" * 63 + "[/bold cyan]"
+    console.print(f"\n{divider}")
     console.print(f"[bold]Model:[/bold] {model_path}")
     console.print("[bold cyan]Generation Config:[/bold cyan]")
-    console.print(f"  max_new_tokens:      {gen_config.max_new_tokens}")
-    console.print(f"  min_new_tokens:      {gen_config.min_new_tokens}")
-    console.print(f"  num_beams:           {gen_config.num_beams}")
-    console.print(f"  do_sample:           {gen_config.do_sample}")
-    console.print(f"  repetition_penalty:  {gen_config.repetition_penalty}")
-    console.print(f"  length_penalty:      {gen_config.length_penalty}")
-    console.print(f"  no_repeat_ngram_size: {gen_config.no_repeat_ngram_size}")
-    console.print(
-        "[bold cyan]═══════════════════════════════════════════════════════════════[/bold cyan]\n"
-    )
+    for attr in (
+        "max_new_tokens",
+        "min_new_tokens",
+        "num_beams",
+        "do_sample",
+        "repetition_penalty",
+        "length_penalty",
+        "no_repeat_ngram_size",
+    ):
+        console.print(f"  {attr:<20} {getattr(gen_config, attr)}")
+    console.print(f"{divider}\n")
 
 
 class LocalEvaluator(Evaluator):
@@ -118,28 +138,10 @@ class LocalStreamingEvaluator(Evaluator):
         print_generation_config(self.model, model_path)
 
     def transcribe(self, audio) -> tuple[str, float]:
-        import threading
-
         from transformers import TextIteratorStreamer
 
-        # Extract audio array
-        if isinstance(audio, dict) and "array" in audio:
-            audio_array = audio["array"]
-            sample_rate = audio.get("sampling_rate", 16000)
-        elif isinstance(audio, dict) and "raw" in audio:
-            audio_array = audio["raw"]
-            sample_rate = audio.get("sampling_rate", 16000)
-        else:
-            wav_bytes = prepare_wav_bytes(audio)
-            audio_array, sample_rate = sf.read(io.BytesIO(wav_bytes))
+        audio_array = _extract_audio_16khz(audio)
 
-        # Resample to 16kHz if needed
-        if sample_rate != 16000:
-            import librosa
-
-            audio_array = librosa.resample(audio_array, orig_sr=sample_rate, target_sr=16000)
-
-        # Process audio (ASRProcessor handles sampling_rate internally)
         inputs = self.processor(
             audio_array,
             return_tensors="pt",
@@ -246,8 +248,6 @@ class EndpointEvaluator(Evaluator):
             temp_path.unlink(missing_ok=True)
 
     def __del__(self):
-        import shutil
-
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
 
@@ -320,28 +320,12 @@ class AssemblyAIStreamingEvaluator(Evaluator):
         self._client.connect(StreamingParameters(sample_rate=16000, format_turns=True))
 
     def transcribe(self, audio) -> tuple[str, float]:
-        import threading
-
         import numpy as np
-        import soundfile as sf
 
         self._ensure_connected()
 
-        # Convert audio to raw PCM bytes (16kHz, 16-bit mono)
-        if isinstance(audio, dict) and "array" in audio:
-            audio_array = audio["array"]
-            sample_rate = audio.get("sampling_rate", 16000)
-        else:
-            wav_bytes = prepare_wav_bytes(audio)
-            audio_array, sample_rate = sf.read(io.BytesIO(wav_bytes))
+        audio_array = _extract_audio_16khz(audio)
 
-        # Resample to 16kHz if needed
-        if sample_rate != 16000:
-            import librosa
-
-            audio_array = librosa.resample(audio_array, orig_sr=sample_rate, target_sr=16000)
-
-        # Convert to 16-bit PCM bytes
         if isinstance(audio_array, np.ndarray):
             if audio_array.dtype != np.float32:
                 audio_array = audio_array.astype(np.float32)

--- a/scripts/eval/evaluators/base.py
+++ b/scripts/eval/evaluators/base.py
@@ -32,11 +32,6 @@ def setup_assemblyai(
     return aai.Transcriber(config=config)
 
 
-# =============================================================================
-# Result Types (using attrs for conciseness)
-# =============================================================================
-
-
 @attrs.define
 class EvalResult:
     """Result of a single ASR sample evaluation."""
@@ -80,9 +75,11 @@ class AlignmentResult:
     predicted_text: str
 
 
-# =============================================================================
-# Base Evaluator
-# =============================================================================
+def _is_skipped_reference(reference) -> bool:
+    """Filter out unscoreable samples (TEDLIUM markers, inaudible)."""
+    if not isinstance(reference, str):
+        return False
+    return reference.strip() == "ignore_time_segment_in_scoring" or "inaudible" in reference.lower()
 
 
 class Evaluator:
@@ -131,34 +128,36 @@ class Evaluator:
 
         return self.results
 
+    def _iter_dataset_samples(self, dataset):
+        """Yield (audio, reference) for samples that pass the skip filter."""
+        for sample in dataset:
+            reference = sample[self.text_field]
+            if _is_skipped_reference(reference):
+                continue
+            yield {"audio": sample[self.audio_field], "reference": reference}
+
+    def _print_sample_log(self, prefix: str, idx: int, result: EvalResult) -> None:
+        norm_pred = self.normalizer.normalize(result.prediction)
+        norm_ref = self.normalizer.normalize(result.reference)
+        print(f"{prefix}Sample {idx}: WER={result.wer:.1f}%, Time={result.time:.2f}s")
+        print(f"  Ref:  {norm_ref}")
+        print(f"  Pred: {norm_pred}")
+
+    def _corpus_wer(self, results: list[EvalResult]) -> float:
+        preds = [self.normalizer.normalize(r.prediction) for r in results]
+        refs = [self.normalizer.normalize(r.reference) for r in results]
+        return jiwer.wer(refs, preds) * 100
+
     def _collect_samples(self, dataset, max_samples: int | None) -> list[dict]:
         """Collect samples for parallel processing."""
         samples_to_process = []
         target = max_samples or "all"
         console.print(f"[dim]Collecting samples (target: {target})...[/dim]")
-        for sample in dataset:
-            reference = sample[self.text_field]
-
-            # Skip TEDLIUM ignore markers
-            if isinstance(reference, str) and reference.strip() == "ignore_time_segment_in_scoring":
-                continue
-
-            # Skip samples marked as inaudible
-            if isinstance(reference, str) and "inaudible" in reference.lower():
-                continue
-
-            samples_to_process.append(
-                {
-                    "audio": sample[self.audio_field],
-                    "reference": reference,
-                }
-            )
-
-            # Progress indicator during collection
+        for s in self._iter_dataset_samples(dataset):
+            samples_to_process.append(s)
             count = len(samples_to_process)
             if count % 50 == 0 or count == max_samples:
                 console.print(f"[dim]  Collected {count} samples...[/dim]")
-
             if max_samples and count >= max_samples:
                 break
 
@@ -169,31 +168,17 @@ class Evaluator:
 
     def _evaluate_sequential_lazy(self, dataset, max_samples: int | None) -> None:
         """Run sequential evaluation lazily (no pre-collection)."""
-        idx = 0
-        for sample in dataset:
-            reference = sample[self.text_field]
-
-            # Skip TEDLIUM ignore markers
-            if isinstance(reference, str) and reference.strip() == "ignore_time_segment_in_scoring":
-                continue
-
-            # Skip samples marked as inaudible
-            if isinstance(reference, str) and "inaudible" in reference.lower():
-                continue
-
-            idx += 1
-            sample_data = {"audio": sample[self.audio_field], "reference": reference}
+        for idx, sample_data in enumerate(self._iter_dataset_samples(dataset), start=1):
             _, result = self._process_sample((idx, sample_data))
             self.results.append(result)
-
-            norm_pred = self.normalizer.normalize(result.prediction)
-            norm_ref = self.normalizer.normalize(result.reference)
-            print(f"Sample {idx}: WER={result.wer:.1f}%, Time={result.time:.2f}s")
-            print(f"  Ref:  {norm_ref}")
-            print(f"  Pred: {norm_pred}")
+            self._print_sample_log("", idx, result)
 
             if idx % 100 == 0:
-                self._print_checkpoint(idx)
+                avg_time = sum(r.time for r in self.results) / len(self.results)
+                console.print(
+                    f"\n[bold]CHECKPOINT @ {idx}[/bold]: "
+                    f"WER={self._corpus_wer(self.results):.2f}%, Avg Time={avg_time:.2f}s\n"
+                )
 
             if max_samples and idx >= max_samples:
                 break
@@ -204,65 +189,38 @@ class Evaluator:
 
         console.print(f"[bold]Running parallel evaluation with {self.num_workers} workers[/bold]")
 
-        # Pre-allocate results list
         results_map: dict[int, EvalResult] = {}
         completed = 0
         total = len(samples)
 
         with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-            # Submit all tasks
             futures = {
                 executor.submit(self._process_sample, (idx, sample)): idx
                 for idx, sample in enumerate(samples, 1)
             }
 
-            # Process as they complete
             for future in as_completed(futures):
                 idx, result = future.result()
                 results_map[idx] = result
                 completed += 1
 
-                norm_pred = self.normalizer.normalize(result.prediction)
-                norm_ref = self.normalizer.normalize(result.reference)
-                print(
-                    f"[{completed}/{total}] Sample {idx}: WER={result.wer:.1f}%, Time={result.time:.2f}s"
-                )
-                print(f"  Ref:  {norm_ref}")
-                print(f"  Pred: {norm_pred}")
+                self._print_sample_log(f"[{completed}/{total}] ", idx, result)
 
                 if completed % 100 == 0:
-                    # Compute checkpoint on completed results
-                    temp_results = list(results_map.values())
-                    preds = [self.normalizer.normalize(r.prediction) for r in temp_results]
-                    refs = [self.normalizer.normalize(r.reference) for r in temp_results]
-                    corpus_wer = jiwer.wer(refs, preds) * 100
+                    corpus_wer = self._corpus_wer(list(results_map.values()))
                     console.print(
                         f"\n[bold]CHECKPOINT @ {completed}[/bold]: WER={corpus_wer:.2f}%\n"
                     )
 
-        # Store results in order
         self.results = [results_map[i] for i in sorted(results_map.keys())]
-
-    def _print_checkpoint(self, sample_count: int):
-        """Print cumulative metrics checkpoint."""
-        preds = [self.normalizer.normalize(r.prediction) for r in self.results]
-        refs = [self.normalizer.normalize(r.reference) for r in self.results]
-        corpus_wer = jiwer.wer(refs, preds) * 100
-        avg_time = sum(r.time for r in self.results) / len(self.results)
-        console.print(
-            f"\n[bold]CHECKPOINT @ {sample_count}[/bold]: WER={corpus_wer:.2f}%, Avg Time={avg_time:.2f}s\n"
-        )
 
     def compute_metrics(self) -> dict:
         """Compute final metrics."""
         if not self.results:
             return {"wer": 0.0, "avg_time": 0.0, "num_samples": 0}
 
-        preds = [self.normalizer.normalize(r.prediction) for r in self.results]
-        refs = [self.normalizer.normalize(r.reference) for r in self.results]
-
         return {
-            "wer": jiwer.wer(refs, preds) * 100,
+            "wer": self._corpus_wer(self.results),
             "avg_time": sum(r.time for r in self.results) / len(self.results),
             "num_samples": len(self.results),
         }

--- a/scripts/eval/evaluators/classification.py
+++ b/scripts/eval/evaluators/classification.py
@@ -253,30 +253,21 @@ class ClassificationEvaluator:
         return self._pipeline
 
     def _get_keywords(self) -> list[str]:
-        """Get keywords for current task."""
-        if self.task == "emotion":
-            return self.EMOTION_KEYWORDS
-        if self.task == "gender":
-            return self.GENDER_KEYWORDS
-        if self.task == "age":
-            return self.AGE_KEYWORDS
-        if self.task == "accent":
-            return self.ACCENT_KEYWORDS
-        if self.task == "rate":
-            return self.SPEAKING_RATE_KEYWORDS
-        return []
+        return {
+            "emotion": self.EMOTION_KEYWORDS,
+            "gender": self.GENDER_KEYWORDS,
+            "age": self.AGE_KEYWORDS,
+            "accent": self.ACCENT_KEYWORDS,
+            "rate": self.SPEAKING_RATE_KEYWORDS,
+        }.get(self.task, [])
 
     def _get_synonyms(self) -> dict[str, str]:
-        """Get synonym mapping for current task."""
-        if self.task == "emotion":
-            return self.EMOTION_SYNONYMS
-        if self.task == "gender":
-            return self.GENDER_SYNONYMS
-        if self.task == "accent":
-            return self.ACCENT_SYNONYMS
-        if self.task == "rate":
-            return self.SPEAKING_RATE_SYNONYMS
-        return {}
+        return {
+            "emotion": self.EMOTION_SYNONYMS,
+            "gender": self.GENDER_SYNONYMS,
+            "accent": self.ACCENT_SYNONYMS,
+            "rate": self.SPEAKING_RATE_SYNONYMS,
+        }.get(self.task, {})
 
     def _normalize_class(self, keyword: str) -> str:
         """Normalize keyword to canonical form using synonyms."""
@@ -375,28 +366,35 @@ class ClassificationEvaluator:
             return ""
         return str(ref)
 
+    def _build_sample_data(self, sample: dict, reference: str) -> dict:
+        return {
+            "audio": sample[self.audio_field],
+            "instruction": self._get_instruction(sample),
+            "reference": reference,
+        }
+
+    def _print_sample_log(self, prefix: str, idx: int, result: ClassificationResult) -> None:
+        status = "correct" if result.correct else "wrong"
+        print(f"{prefix}Sample {idx}: {status} Time={result.time:.2f}s")
+        print(f"  Pred: {result.prediction[:100]}")
+        print(f"  Ref: {result.reference}")
+
+    def _iter_valid_samples(self, dataset):
+        for sample in dataset:
+            reference = self._get_reference(sample)
+            if not reference:
+                continue
+            yield sample, reference
+
     def _collect_samples(self, dataset, max_samples: int | None) -> list[dict]:
         """Collect samples for parallel processing."""
         samples = []
         console.print(f"[dim]Collecting samples (target: {max_samples or 'all'})...[/dim]")
 
-        for sample in dataset:
-            reference = self._get_reference(sample)
-            # Skip samples with empty reference
-            if not reference:
-                continue
-
-            samples.append(
-                {
-                    "audio": sample[self.audio_field],
-                    "instruction": self._get_instruction(sample),
-                    "reference": reference,
-                }
-            )
-
+        for sample, reference in self._iter_valid_samples(dataset):
+            samples.append(self._build_sample_data(sample, reference))
             if len(samples) % 100 == 0:
                 console.print(f"[dim]  Collected {len(samples)} samples...[/dim]")
-
             if max_samples and len(samples) >= max_samples:
                 break
 
@@ -405,27 +403,11 @@ class ClassificationEvaluator:
 
     def _evaluate_sequential(self, dataset, max_samples: int | None) -> None:
         """Run sequential evaluation."""
-        idx = 0
-        for sample in dataset:
-            reference = self._get_reference(sample)
-            # Skip samples with empty reference
-            if not reference:
-                continue
-
-            idx += 1
-            sample_data = {
-                "audio": sample[self.audio_field],
-                "instruction": self._get_instruction(sample),
-                "reference": reference,
-            }
-
-            _, result = self._process_sample((idx, sample_data))
+        for idx, (sample, reference) in enumerate(self._iter_valid_samples(dataset), start=1):
+            _, result = self._process_sample((idx, self._build_sample_data(sample, reference)))
             self.results.append(result)
 
-            status = "correct" if result.correct else "wrong"
-            print(f"Sample {idx}: {status} Time={result.time:.2f}s")
-            print(f"  Pred: {result.prediction[:100]}")
-            print(f"  Ref: {result.reference}")
+            self._print_sample_log("", idx, result)
 
             if idx % 100 == 0:
                 self._print_checkpoint(idx)
@@ -452,10 +434,7 @@ class ClassificationEvaluator:
                 results_map[idx] = result
                 completed += 1
 
-                status = "correct" if result.correct else "wrong"
-                print(f"[{completed}/{total}] Sample {idx}: {status} Time={result.time:.2f}s")
-                print(f"  Pred: {result.prediction[:100]}")
-                print(f"  Ref: {result.reference}")
+                self._print_sample_log(f"[{completed}/{total}] ", idx, result)
 
                 if completed % 100 == 0:
                     temp_results = list(results_map.values())

--- a/scripts/eval/evaluators/diarization.py
+++ b/scripts/eval/evaluators/diarization.py
@@ -60,27 +60,23 @@ class DiarizationEvaluator:
 
     def diarize(self, audio) -> tuple[list[dict], float]:
         """Run diarization on audio and return (segments, inference_time)."""
-        import io
-
         import librosa
 
         from tiny_audio.asr_pipeline import SpeakerDiarizer
 
-        # Prepare audio array - handle both decoded and raw bytes formats
         if isinstance(audio, dict):
             if "array" in audio:
-                # Already decoded
                 audio_array = audio["array"]
                 sample_rate = audio.get("sampling_rate", 16000)
             elif "bytes" in audio:
-                # Raw bytes - decode with librosa (avoids torchcodec CPU issues)
+                # Raw bytes — decode with librosa to avoid torchcodec CPU issues.
                 audio_array, sample_rate = librosa.load(io.BytesIO(audio["bytes"]), sr=16000)
             else:
                 raise ValueError(f"Unsupported audio dict format: {audio.keys()}")
         else:
             raise ValueError(f"Unsupported audio format: {type(audio)}")
 
-        # Ensure float32 dtype (pyannote requires consistent dtype)
+        # pyannote requires consistent float32 dtype.
         if hasattr(audio_array, "astype"):
             audio_array = audio_array.astype(np.float32)
 
@@ -160,38 +156,29 @@ class DiarizationEvaluator:
 
         self.results = []
 
-        # Collect samples up to max_samples
         samples = []
         for i, sample in enumerate(dataset):
             if max_samples and i >= max_samples:
                 break
             samples.append((sample, i + 1))
 
+        def collect(result):
+            if result is not None:
+                self.results.append(result)
+            if len(self.results) > 0 and len(self.results) % 50 == 0:
+                self._print_checkpoint(len(self.results))
+
         if self.num_workers > 1:
-            # Parallel processing
             with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
                 futures = {
                     executor.submit(self._process_sample, sample, idx): idx
                     for sample, idx in samples
                 }
                 for future in as_completed(futures):
-                    result = future.result()
-                    if result is not None:
-                        self.results.append(result)
-
-                    # Checkpoint every 50 samples
-                    if len(self.results) % 50 == 0 and len(self.results) > 0:
-                        self._print_checkpoint(len(self.results))
+                    collect(future.result())
         else:
-            # Sequential processing
             for sample, idx in samples:
-                result = self._process_sample(sample, idx)
-                if result is not None:
-                    self.results.append(result)
-
-                # Checkpoint every 50 samples
-                if len(self.results) % 50 == 0 and len(self.results) > 0:
-                    self._print_checkpoint(len(self.results))
+                collect(self._process_sample(sample, idx))
 
         return self.results
 

--- a/scripts/eval/evaluators/mcq.py
+++ b/scripts/eval/evaluators/mcq.py
@@ -3,6 +3,7 @@
 import io
 import json
 import time
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import attrs
@@ -156,6 +157,22 @@ class MMAUEvaluator:
             category=sample["category"],
         )
 
+    def _build_sample_data(self, sample: dict) -> dict:
+        return {
+            "audio": sample[self.audio_field],
+            "question": sample[self.question_field],
+            "reference": sample[self.answer_field],
+            "choices": sample[self.choices_field],
+            "category": self._extract_category(sample.get(self.category_field, "")),
+        }
+
+    def _print_sample_log(self, prefix: str, idx: int, result: MCQResult) -> None:
+        status = "✓" if result.correct else "✗"
+        print(f"{prefix}Sample {idx}: {status} Time={result.time:.2f}s")
+        print(f"  Q: {result.question}")
+        print(f"  Pred: {result.prediction[:100]}")
+        print(f"  Match: {result.matched_choice} | Ref: {result.reference}")
+
     def evaluate(self, dataset, max_samples: int | None = None) -> list[MCQResult]:
         """Run evaluation loop on dataset."""
         self.results = []
@@ -174,15 +191,7 @@ class MMAUEvaluator:
         console.print(f"[dim]Collecting samples (target: {max_samples or 'all'})...[/dim]")
 
         for sample in dataset:
-            samples.append(
-                {
-                    "audio": sample[self.audio_field],
-                    "question": sample[self.question_field],
-                    "reference": sample[self.answer_field],
-                    "choices": sample[self.choices_field],
-                    "category": self._extract_category(sample.get(self.category_field, "")),
-                }
-            )
+            samples.append(self._build_sample_data(sample))
 
             if len(samples) % 100 == 0:
                 console.print(f"[dim]  Collected {len(samples)} samples...[/dim]")
@@ -196,22 +205,10 @@ class MMAUEvaluator:
     def _evaluate_sequential(self, dataset, max_samples: int | None) -> None:
         """Run sequential evaluation."""
         for idx, sample in enumerate(dataset, 1):
-            sample_data = {
-                "audio": sample[self.audio_field],
-                "question": sample[self.question_field],
-                "reference": sample[self.answer_field],
-                "choices": sample[self.choices_field],
-                "category": self._extract_category(sample.get(self.category_field, "")),
-            }
-
-            _, result = self._process_sample((idx, sample_data))
+            _, result = self._process_sample((idx, self._build_sample_data(sample)))
             self.results.append(result)
 
-            status = "✓" if result.correct else "✗"
-            print(f"Sample {idx}: {status} Time={result.time:.2f}s")
-            print(f"  Q: {result.question}")
-            print(f"  Pred: {result.prediction[:100]}")
-            print(f"  Match: {result.matched_choice} | Ref: {result.reference}")
+            self._print_sample_log("", idx, result)
 
             if idx % 100 == 0:
                 self._print_checkpoint(idx)
@@ -238,11 +235,7 @@ class MMAUEvaluator:
                 results_map[idx] = result
                 completed += 1
 
-                status = "✓" if result.correct else "✗"
-                print(f"[{completed}/{total}] Sample {idx}: {status} Time={result.time:.2f}s")
-                print(f"  Q: {result.question}")
-                print(f"  Pred: {result.prediction[:100]}")
-                print(f"  Match: {result.matched_choice} | Ref: {result.reference}")
+                self._print_sample_log(f"[{completed}/{total}] ", idx, result)
 
                 if completed % 100 == 0:
                     temp_results = list(results_map.values())
@@ -267,11 +260,8 @@ class MMAUEvaluator:
         total = len(self.results)
         correct = sum(1 for r in self.results if r.correct)
 
-        # Per-category accuracy
-        categories: dict[str, list[MCQResult]] = {}
+        categories: dict[str, list[MCQResult]] = defaultdict(list)
         for r in self.results:
-            if r.category not in categories:
-                categories[r.category] = []
             categories[r.category].append(r)
 
         category_acc = {

--- a/scripts/generate_sift_dataset.py
+++ b/scripts/generate_sift_dataset.py
@@ -1,17 +1,5 @@
 #!/usr/bin/env python3
-"""Generate SIFT datasets for paralinguistic training.
-
-This script processes audio datasets with paralinguistic metadata (emotion, gender, age)
-and generates natural language responses using an LLM.
-
-Uses SIT_SSP mode: System message + instruction + semantic + paralinguistic
-
-Usage:
-    python -m scripts.generate_sift_dataset --output-repo user/sift-dataset
-
-    # On RunPod via CLI:
-    ta runpod sift <host> <port> --output-repo user/sift-dataset
-"""
+"""Generate SIFT datasets for paralinguistic training."""
 
 import os
 import re
@@ -29,16 +17,22 @@ from tqdm import tqdm
 from transformers import AutoTokenizer, GenerationConfig, pipeline
 from transformers.pipelines.pt_utils import KeyDataset
 
-# System prompt for audio understanding (optimized through iterative testing with Qwen3-4B)
-# Produces natural, human-like descriptions with voice quality details
 SIFT_SYSTEM_PROMPT = (
     'Describe the audio in one sentence starting with "Sounds like".\n'
     "Include: emotion, speaker gender, what they said (quoted), and voice quality.\n"
     "Example: \"Sounds like an angry man saying 'leave me alone' in a harsh, loud voice.\""
 )
-
-# Simple instruction to trigger description
 SIFT_INSTRUCTION = "/no_think"
+
+MISSING_VALUE_SENTINELS = frozenset({"", "na", "null", "unk", "unknown", "nan", "none"})
+
+
+def _clean_string(value: object) -> str | None:
+    """Lowercase and strip a value; return None if it represents a missing value."""
+    if value is None:
+        return None
+    cleaned = str(value).lower().strip()
+    return None if cleaned in MISSING_VALUE_SENTINELS else cleaned
 
 
 @dataclass
@@ -181,133 +175,87 @@ def age_to_group(age: str | int | None) -> str | None:
         return None
     try:
         age_int = int(age)
-        if 0 < age_int < 18:
-            return "teenager"
-        if age_int < 40:
-            return "young adult"
-        if age_int <= 60:
-            return "middle-age adult"
-        if 60 < age_int < 200:
-            return "senior"
-        return None
     except (ValueError, TypeError):
-        # Already a string like "young adult"
-        if isinstance(age, str) and age.lower() not in ("", "na", "null", "unk", "unknown", "nan"):
-            return age.lower()
-        return None
+        return _clean_string(age)
+    if 0 < age_int < 18:
+        return "teenager"
+    if age_int < 40:
+        return "young adult"
+    if age_int <= 60:
+        return "middle-age adult"
+    if 60 < age_int < 200:
+        return "senior"
+    return None
 
 
 def volume_to_label(relative_db: float | None) -> str | None:
     """Convert relative_db to volume label.
 
-    Thresholds derived from AbstractTTS dataset distributions:
-    - Quiet: < -16.4 dB (below 25th percentile)
-    - Normal: -16.4 to -10.0 dB (25th to 75th percentile)
-    - Loud: > -10.0 dB (above 75th percentile)
-
-    Returns None for normal volume (don't mention unremarkable features).
+    Thresholds (AbstractTTS dataset distributions):
+      - quiet: < -16.4 dB (below 25th percentile)
+      - loud:  > -10.0 dB (above 75th percentile)
+      - normal: between (returns None — don't mention unremarkable features)
     """
     if relative_db is None:
         return None
-
     if relative_db < -16.4:
         return "quiet"
     if relative_db > -10.0:
         return "loud"
-    return None  # Normal volume - don't mention
+    return None
 
 
 def pace_to_label(rate: str | float | None) -> str | None:
-    """Convert numeric speaking rate to text label. Returns None for missing/invalid values.
+    """Convert numeric speaking rate to text label.
 
-    Speaking rate thresholds based on AbstractTTS dataset distributions:
-    - Data ranges from ~3-17 with median ~7-10
-    - Slow: < 6.0 (bottom ~25%)
-    - Normal: 6.0 - 9.0 (middle ~50%)
-    - Fast: > 9.0 (top ~25%)
+    Thresholds (AbstractTTS dataset distributions, range ~3-17):
+      - slow:   < 6.0
+      - normal: 6.0 - 9.0
+      - fast:   > 9.0
     """
     if rate is None:
         return None
     try:
         rate_float = float(rate)
-        if rate_float <= 0:
-            return None
-        if rate_float < 6.0:
-            return "slow"
-        if rate_float <= 9.0:
-            return "normal"
-        return "fast"
     except (ValueError, TypeError):
-        # Already a string like "fast", "slow", "normal"
-        if isinstance(rate, str) and rate.lower() not in (
-            "",
-            "na",
-            "null",
-            "unk",
-            "unknown",
-            "nan",
-        ):
-            return rate.lower()
+        return _clean_string(rate)
+    if rate_float <= 0:
         return None
+    if rate_float < 6.0:
+        return "slow"
+    if rate_float <= 9.0:
+        return "normal"
+    return "fast"
 
 
 def normalize_label(value: str | None) -> str | None:
     """Normalize a label value. Returns None for missing/invalid values."""
-    if value is None:
-        return None
-    value_str = str(value).lower().strip()
-    if value_str in ("", "na", "null", "unk", "unknown", "nan", "none"):
-        return None
-    return value_str
+    return _clean_string(value)
 
 
-# Emotion label normalization mapping
-# Maps various dataset-specific labels to consistent canonical forms
 EMOTION_NORMALIZATION = {
-    # Anger variants
-    "angry": "angry",
     "anger": "angry",
-    # Happiness variants
-    "happy": "happy",
     "happiness": "happy",
-    # Sadness variants
-    "sad": "sad",
     "sadness": "sad",
-    # Surprise variants
-    "surprise": "surprise",
     "surprised": "surprise",
     "pleasant surprise": "surprise",
-    # Standard labels (no change needed)
-    "neutral": "neutral",
-    "fear": "fear",
-    "disgust": "disgust",
 }
 
 
 def normalize_emotion(value: str | None) -> str | None:
-    """Normalize emotion labels to consistent canonical forms.
-
-    Different datasets use different labels for the same emotion:
-    - TESS: angry, happy, sad, pleasant surprise
-    - SAVEE: anger, happiness, sadness, surprise
-    - CREMA-D: anger, happy, sad
-
-    This normalizes them to: angry, happy, sad, surprise, neutral, fear, disgust
-    """
-    if value is None:
+    """Normalize dataset-specific emotion labels (e.g. anger→angry, happiness→happy)."""
+    cleaned = _clean_string(value)
+    if cleaned is None:
         return None
-    value_lower = str(value).lower().strip()
-    if value_lower in ("", "na", "null", "unk", "unknown", "nan", "none"):
-        return None
-    return EMOTION_NORMALIZATION.get(value_lower, value_lower)
+    return EMOTION_NORMALIZATION.get(cleaned, cleaned)
 
 
-# MELD emotion mapping (integer to string)
+# MELD uses integer emotion labels; joy maps to "happy" for consistency with other datasets.
 MELD_EMOTION_MAP = {
     0: "angry",
     1: "disgust",
     2: "fear",
-    3: "happy",  # joy -> happy for consistency
+    3: "happy",
     4: "neutral",
     5: "sad",
     6: "surprise",
@@ -315,13 +263,13 @@ MELD_EMOTION_MAP = {
 
 
 def normalize_meld_emotion(value: int | str | None) -> str | None:
-    """Convert MELD emotion integer to string label."""
-    if value is None:
-        return None
+    """Convert MELD emotion integer (or string) to canonical label."""
     if isinstance(value, int):
-        label = MELD_EMOTION_MAP.get(value)
-        return normalize_emotion(label) if label else None
+        return normalize_emotion(MELD_EMOTION_MAP.get(value))
     return normalize_emotion(value)
+
+
+METADATA_KEYS = ("text", "emotion", "gender", "age", "pace", "accent", "volume")
 
 
 def extract_metadata(sample: dict, config: DatasetConfig) -> dict:
@@ -330,97 +278,55 @@ def extract_metadata(sample: dict, config: DatasetConfig) -> dict:
     Returns empty strings instead of None to ensure consistent schema
     across multiprocessing batches in datasets.map().
     """
-    metadata = {
-        "text": "",
-        "emotion": "",
-        "gender": "",
-        "age": "",
-        "pace": "",
-        "accent": "",
-        "volume": "",
-    }
+    metadata: dict = dict.fromkeys(METADATA_KEYS, "")
 
-    # Extract text transcription
-    if config.text_field and config.text_field in sample:
-        text = sample[config.text_field]
-        if text:
-            metadata["text"] = str(text).strip().lower()
+    if config.text_field and (text := sample.get(config.text_field)):
+        metadata["text"] = str(text).strip().lower()
 
-    # Extract emotion (handle integer labels for MELD)
     if config.emotion_field and config.emotion_field in sample:
-        raw_emotion = sample[config.emotion_field]
-        if config.emotion_is_int:
-            metadata["emotion"] = normalize_meld_emotion(raw_emotion)
-        else:
-            metadata["emotion"] = normalize_emotion(raw_emotion)
+        raw = sample[config.emotion_field]
+        metadata["emotion"] = (
+            normalize_meld_emotion(raw) if config.emotion_is_int else normalize_emotion(raw)
+        )
 
-    # Extract gender
     if config.gender_field and config.gender_field in sample:
         gender = normalize_label(sample[config.gender_field])
-        # Normalize gender values
         if gender in ("m", "male"):
             gender = "male"
         elif gender in ("f", "female"):
             gender = "female"
         metadata["gender"] = gender
 
-    # Extract age
     if config.age_field and config.age_field in sample:
         metadata["age"] = age_to_group(sample[config.age_field])
 
-    # Extract speaking rate (convert numeric to label if needed)
     if config.pace_field and config.pace_field in sample:
-        raw_rate = sample[config.pace_field]
-        metadata["pace"] = pace_to_label(raw_rate)
+        metadata["pace"] = pace_to_label(sample[config.pace_field])
 
-    # Extract accent
     if config.accent_field and config.accent_field in sample:
-        accent = normalize_label(sample[config.accent_field])
-        metadata["accent"] = accent
+        metadata["accent"] = normalize_label(sample[config.accent_field])
 
-    # Extract volume (relative dB)
     if config.volume_field and config.volume_field in sample:
-        raw_volume = sample[config.volume_field]
-        metadata["volume"] = volume_to_label(raw_volume)
+        metadata["volume"] = volume_to_label(sample[config.volume_field])
 
     return metadata
 
 
+# Order: demographics first, then voice characteristics, then content-related.
+PARA_ORDER = ("age", "gender", "volume", "pace", "emotion", "accent")
+
+
 def build_audio_context(metadata: dict) -> str:
-    """Build audio context with metadata for the LLM.
-
-    Args:
-        metadata: Extracted metadata from the audio sample
-
-    Returns:
-        Audio context string with metadata in tags
-    """
-    # Build paralinguistic metadata
-    # Order: demographics first, then voice characteristics, then content-related
-    para_parts = []
-    for key in [
-        "age",
-        "gender",
-        "volume",
-        "pace",
-        "emotion",
-        "accent",
-    ]:
-        value = metadata.get(key)
-        if value:  # Skip empty strings and None
-            display_key = key.replace("_", " ")
-            para_parts.append(f"{display_key}: {value}")
-
-    # Format input with audio tags
-    if para_parts and metadata["text"]:
-        para_text = ", ".join(para_parts)
-        return f"<audio><meta>{para_text}</meta><text>{metadata['text']}</text></audio>"
+    """Build audio context with metadata for the LLM."""
+    para_parts = [
+        f"{key.replace('_', ' ')}: {value}" for key in PARA_ORDER if (value := metadata.get(key))
+    ]
+    inner = ""
     if para_parts:
-        para_text = ", ".join(para_parts)
-        return f"<audio><meta>{para_text}</meta></audio>"
+        inner += f"<meta>{', '.join(para_parts)}</meta>"
     if metadata["text"]:
-        return f"<audio><text>{metadata['text']}</text></audio>"
-    return "<audio></audio>"
+        inner += f"<text>{metadata['text']}</text>"
+    return f"<audio>{inner}</audio>"
 
 
 def create_dataset_card(repo_id: str, splits: list[str]) -> None:
@@ -513,41 +419,23 @@ def process_dataset(
         trust_remote_code=True,
     )
 
-    # Limit samples first (faster than filtering all)
-    if config.max_samples is not None and max_samples is not None:
-        effective_max = min(config.max_samples, max_samples)
-    elif config.max_samples is not None:
-        effective_max = config.max_samples
-    elif max_samples is not None:
-        effective_max = max_samples
-    else:
-        effective_max = None
-
+    caps = [m for m in (config.max_samples, max_samples) if m is not None]
+    effective_max = min(caps) if caps else None
     if effective_max and len(ds) > effective_max:
         ds = ds.select(range(effective_max))
 
     print(f"  Loaded {len(ds)} samples")
-
-    # Extract metadata and build prompts (simple loop is faster than multiprocess map for this)
     print("  Preparing prompts...")
+
     prompts = []
-    metadata_lists = {
-        "text": [],
-        "emotion": [],
-        "gender": [],
-        "age": [],
-        "pace": [],
-        "accent": [],
-        "volume": [],
-    }
+    metadata_lists: dict[str, list] = {key: [] for key in METADATA_KEYS}
 
     for sample in tqdm(ds, desc="Preparing", total=len(ds)):
         metadata = extract_metadata(sample, config)
         for key in metadata_lists:
             metadata_lists[key].append(metadata[key])
 
-        audio_context = build_audio_context(metadata)
-        user_content = f"{audio_context}\n\n{SIFT_INSTRUCTION}"
+        user_content = f"{build_audio_context(metadata)}\n\n{SIFT_INSTRUCTION}"
         messages = [
             {"role": "system", "content": SIFT_SYSTEM_PROMPT},
             {"role": "user", "content": user_content},
@@ -558,17 +446,10 @@ def process_dataset(
             )
         )
 
-    # Add columns to dataset
     ds = ds.add_column("prompt", prompts)
-    ds = ds.add_column("meta_text", metadata_lists["text"])
-    ds = ds.add_column("meta_emotion", metadata_lists["emotion"])
-    ds = ds.add_column("meta_gender", metadata_lists["gender"])
-    ds = ds.add_column("meta_age", metadata_lists["age"])
-    ds = ds.add_column("meta_pace", metadata_lists["pace"])
-    ds = ds.add_column("meta_accent", metadata_lists["accent"])
-    ds = ds.add_column("meta_volume", metadata_lists["volume"])
+    for key, values in metadata_lists.items():
+        ds = ds.add_column(f"meta_{key}", values)
 
-    # Generate responses using pipeline with dataset (more efficient than .map())
     print("  Generating instructions and responses...")
     thinking_pattern = re.compile(r"<think>.*?</think>", re.DOTALL)
     generation_config = GenerationConfig(
@@ -589,66 +470,24 @@ def process_dataset(
         total=len(ds),
         desc="Generating",
     ):
-        text = thinking_pattern.sub("", out[0]["generated_text"]).strip()
-        responses.append(text)
+        responses.append(thinking_pattern.sub("", out[0]["generated_text"]).strip())
 
     ds = ds.add_column("sift_response", responses)
 
-    # Remove original columns that would conflict with our renamed columns
-    conflict_cols = [
-        c
-        for c in [
-            "text",
-            "emotion",
-            "gender",
-            "age",
-            "pace",
-            "accent",
-            "volume",
-        ]
-        if c in ds.column_names
-    ]
+    conflict_cols = [c for c in METADATA_KEYS if c in ds.column_names]
     if conflict_cols:
         ds = ds.remove_columns(conflict_cols)
 
-    # Rename meta columns to final names
-    ds = ds.rename_columns(
-        {
-            "meta_text": "text",
-            "meta_emotion": "emotion",
-            "meta_gender": "gender",
-            "meta_age": "age",
-            "meta_pace": "pace",
-            "meta_accent": "accent",
-            "meta_volume": "volume",
-        }
-    )
+    ds = ds.rename_columns({f"meta_{key}": key for key in METADATA_KEYS})
     ds = ds.add_column("source_dataset", [config.name] * len(ds))
 
-    # Keep only needed columns
-    keep_cols = [
-        "audio",
-        "text",
-        "emotion",
-        "gender",
-        "age",
-        "pace",
-        "accent",
-        "volume",
-        "sift_response",
-        "source_dataset",
-    ]
+    keep_cols = ("audio", *METADATA_KEYS, "sift_response", "source_dataset")
     remove_cols = [c for c in ds.column_names if c not in keep_cols]
     if remove_cols:
         ds = ds.remove_columns(remove_cols)
 
-    # Cast columns to consistent types
-    ds = ds.cast_column("emotion", Value("string"))
-    ds = ds.cast_column("gender", Value("string"))
-    ds = ds.cast_column("age", Value("string"))
-    ds = ds.cast_column("pace", Value("string"))
-    ds = ds.cast_column("accent", Value("string"))
-    ds = ds.cast_column("volume", Value("string"))
+    for col in ("emotion", "gender", "age", "pace", "accent", "volume"):
+        ds = ds.cast_column(col, Value("string"))
     return ds.cast_column("audio", Audio(sampling_rate=16000))
 
 
@@ -672,15 +511,9 @@ def main(
     push_every: Annotated[int, typer.Option(help="Push to hub every N datasets")] = 1,
 ):
     """Generate SIFT datasets for paralinguistic training."""
-    # Filter datasets if specified (support comma-separated values)
     configs = DATASET_CONFIGS
     if datasets:
-        # Expand comma-separated values: ["a,b", "c"] -> ["a", "b", "c"]
-        expanded = []
-        for d in datasets:
-            expanded.extend(d.split(","))
-        dataset_names = [d.strip() for d in expanded if d.strip()]
-
+        dataset_names = {name.strip() for d in datasets for name in d.split(",") if name.strip()}
         configs = [c for c in configs if c.name in dataset_names]
         if not configs:
             typer.echo(
@@ -692,7 +525,6 @@ def main(
     typer.echo(f"Model: {model_name}")
     typer.echo(f"Output: {output_repo}")
 
-    # Load tokenizer and create pipeline
     typer.echo(f"\nLoading model {model_name}...")
     tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
     if tokenizer.pad_token is None:
@@ -707,11 +539,8 @@ def main(
         model_kwargs={"attn_implementation": "flash_attention_2"},
     )
 
-    # Process each dataset
     all_datasets = {}
-    datasets_processed = 0
-
-    for config in configs:
+    for i, config in enumerate(configs, start=1):
         try:
             ds = process_dataset(
                 config=config,
@@ -721,17 +550,6 @@ def main(
                 max_samples=max_samples,
                 max_new_tokens=max_new_tokens,
             )
-
-            if ds is not None:
-                all_datasets[config.name] = ds
-                datasets_processed += 1
-
-                # Push periodically
-                if datasets_processed % push_every == 0:
-                    typer.echo(f"\nPushing {len(all_datasets)} splits to {output_repo}...")
-                    dataset_dict = DatasetDict(all_datasets)
-                    dataset_dict.push_to_hub(output_repo, private=False)
-
         except Exception as e:
             import traceback
 
@@ -739,19 +557,25 @@ def main(
             traceback.print_exc()
             continue
 
-    # Final push
-    if all_datasets:
-        typer.echo(f"\nFinal push: {len(all_datasets)} splits to {output_repo}...")
-        dataset_dict = DatasetDict(all_datasets)
-        dataset_dict.push_to_hub(output_repo, private=False)
+        if ds is None:
+            continue
+        all_datasets[config.name] = ds
 
-        # Update dataset card
-        typer.echo("Updating dataset card...")
-        create_dataset_card(output_repo, list(all_datasets.keys()))
+        if i % push_every == 0:
+            typer.echo(f"\nPushing {len(all_datasets)} splits to {output_repo}...")
+            DatasetDict(all_datasets).push_to_hub(output_repo, private=False)
 
-        typer.echo("Done!")
-    else:
+    if not all_datasets:
         typer.echo("No datasets were successfully processed.")
+        return
+
+    typer.echo(f"\nFinal push: {len(all_datasets)} splits to {output_repo}...")
+    DatasetDict(all_datasets).push_to_hub(output_repo, private=False)
+
+    typer.echo("Updating dataset card...")
+    create_dataset_card(output_repo, list(all_datasets.keys()))
+
+    typer.echo("Done!")
 
 
 if __name__ == "__main__":

--- a/scripts/hub/push.py
+++ b/scripts/hub/push.py
@@ -35,29 +35,24 @@ def main(
     ] = None,
 ):
     """Push model files to Hugging Face Hub."""
-    # Check for HF_TOKEN
     if not os.environ.get("HF_TOKEN"):
         console.print("[red]Error: HF_TOKEN environment variable must be set[/red]")
         raise typer.Exit(1)
 
     api = HfApi(token=os.environ["HF_TOKEN"])
 
-    # Create a temporary directory for staging files
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
 
-        # Create .gitattributes to prevent tokenizer_config.json from being stored in LFS
-        # This fixes "Configuration Parsing Warning: Invalid JSON" on Hub
-        gitattributes_content = """*.safetensors filter=lfs diff=lfs merge=lfs -text
-*.bin filter=lfs diff=lfs merge=lfs -text
-tokenizer_config.json -filter -diff -merge text
-"""
-        gitattributes_path = temp_path / ".gitattributes"
-        gitattributes_path.write_text(gitattributes_content)
+        # Excluding tokenizer_config.json from LFS prevents the "Invalid JSON"
+        # configuration warning on the Hub.
+        (temp_path / ".gitattributes").write_text(
+            "*.safetensors filter=lfs diff=lfs merge=lfs -text\n"
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n"
+            "tokenizer_config.json -filter -diff -merge text\n"
+        )
         console.print("Created .gitattributes (excludes tokenizer_config.json from LFS)")
 
-        # Copy all custom ASR Python files for trust_remote_code support
-        # Include handler.py for Inference Endpoints support
         custom_files = [
             "asr_config.py",
             "asr_modeling.py",
@@ -66,51 +61,39 @@ tokenizer_config.json -filter -diff -merge text
             "projectors.py",
             "alignment.py",
             "diarization.py",
-            "handler.py",  # For Inference Endpoints
+            "handler.py",
         ]
         for filename in custom_files:
             src = Path("tiny_audio") / filename
-            dst = temp_path / filename
             if src.exists():
-                shutil.copy2(src, dst)
-                if filename == "handler.py":
-                    console.print(f"Copied {src} to staging (for Inference Endpoints)")
-                else:
-                    console.print(f"Copied {src} to staging")
+                shutil.copy2(src, temp_path / filename)
+                suffix = " (for Inference Endpoints)" if filename == "handler.py" else ""
+                console.print(f"Copied {src} to staging{suffix}")
             else:
                 console.print(f"[yellow]Warning: {src} not found, skipping[/yellow]")
 
-        # Copy MODEL_CARD.md as README.md
-        model_card_src = Path("MODEL_CARD.md")
-        if model_card_src.exists():
-            readme_dst = temp_path / "README.md"
-            shutil.copy2(model_card_src, readme_dst)
-            console.print(f"Copied {model_card_src} as README.md to staging")
+        # MODEL_CARD.md is published as README.md on the Hub.
+        if Path("MODEL_CARD.md").exists():
+            shutil.copy2("MODEL_CARD.md", temp_path / "README.md")
+            console.print("Copied MODEL_CARD.md as README.md to staging")
 
-        # Copy requirements.txt for model dependencies
-        requirements_src = Path("requirements.txt")
-        if requirements_src.exists():
-            requirements_dst = temp_path / "requirements.txt"
-            shutil.copy2(requirements_src, requirements_dst)
-            console.print(f"Copied {requirements_src} to staging")
+        if Path("requirements.txt").exists():
+            shutil.copy2("requirements.txt", temp_path / "requirements.txt")
+            console.print("Copied requirements.txt to staging")
 
-        # Copy tokenizer files from checkpoint directory if provided
         if checkpoint_dir:
             checkpoint_path = Path(checkpoint_dir)
-            tokenizer_files = [
+            for filename in (
                 "tokenizer_config.json",
                 "tokenizer.json",
                 "special_tokens_map.json",
                 "added_tokens.json",
-            ]
-            for filename in tokenizer_files:
+            ):
                 src = checkpoint_path / filename
                 if src.exists():
-                    dst = temp_path / filename
-                    shutil.copy2(src, dst)
+                    shutil.copy2(src, temp_path / filename)
                     console.print(f"Copied {src} to staging")
 
-        # Upload files to Hub
         console.print(f"\nUploading to {repo_id}...")
         api.upload_folder(
             folder_path=temp_dir,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""Training script for ASR models using Hydra configuration.
-
-This script handles:
-- Loading and preparing datasets from multiple sources
-- Creating ASR models with configurable projector types
-- Training with HuggingFace Trainer and optional WandB logging
-- Checkpoint saving and Hub pushing
-
-Usage:
-    poetry run python scripts/train.py +experiments=transcription
-    poetry run python scripts/train.py training.learning_rate=1e-4
-"""
+"""Training script for ASR models using Hydra configuration."""
 
 import contextlib
 import os
@@ -42,12 +31,7 @@ from trl.experimental.utils import DataCollatorForChatML
 from tiny_audio.asr_config import ASRConfig
 from tiny_audio.asr_modeling import ASRModel
 
-# Prompts for ASR training (transcription task)
-# Focus on exact words only - no mention of description/emotion
 TRANSCRIBE_PROMPTS = ["Transcribe the speech to text"]
-
-# Prompts for SIFT training (description task)
-# Focus on characteristics/delivery - the response naturally includes words
 DESCRIBE_PROMPTS = ["Describe all the information you can hear"]
 
 
@@ -162,7 +146,6 @@ class DatasetLoader:
 class DataCollator:
     """Collates audio and text data for training."""
 
-    # Default conv layers for Whisper/GLM-ASR: [(pad, kernel, stride), ...]
     DEFAULT_ENCODER_CONV_LAYERS = [(1, 3, 1), (1, 3, 2)]
 
     def __init__(
@@ -180,31 +163,22 @@ class DataCollator:
         self.system_prompt = system_prompt
         self.projector = projector
         self.encoder_conv_layers = encoder_conv_layers or self.DEFAULT_ENCODER_CONV_LAYERS
-        # Whisper's encoder requires a fixed 3000 mel frames; pad to its
-        # built-in max_length. GLM-ASR and other variable-length encoders
-        # only need padding to the longest sample in the batch.
+        # Whisper's encoder requires a fixed 3000 mel frames; other encoders
+        # (GLM-ASR) accept variable-length input, so only pad to longest.
         self._audio_padding = (
             "max_length"
             if type(feature_extractor).__name__ == "WhisperFeatureExtractor"
             else "longest"
         )
-
-        # Use trl's DataCollatorForChatML for label masking
-        # max_length needs to accommodate audio tokens (1500 for 30s) + prompt + response
-        self.text_collator = DataCollatorForChatML(
-            tokenizer=tokenizer,
-            max_length=2048,
-        )
+        self.text_collator = DataCollatorForChatML(tokenizer=tokenizer, max_length=2048)
 
     def _compute_encoder_output_length(self, mel_length: int) -> int:
-        """Compute encoder output length using conv layer formulas."""
         length = mel_length
         for padding, kernel_size, stride in self.encoder_conv_layers:
             length = (length + 2 * padding - (kernel_size - 1) - 1) // stride + 1
         return length
 
-    def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
-        # Process audio
+    def _extract_audio_arrays(self, features):
         audio_arrays = []
         valid_features = []
         for f in features:
@@ -221,9 +195,26 @@ class DataCollator:
                 continue
             finally:
                 f["audio"] = None
-
         if not audio_arrays:
             raise ValueError("No valid audio samples in batch")
+        return audio_arrays, valid_features
+
+    def _build_sample(self, feature: dict, num_audio_tokens: int) -> dict:
+        """Build a single chat sample. Subclasses can override for task-specific prompts."""
+        text = (feature.get("text") or "").strip().lower()
+        return self._make_messages(num_audio_tokens, random.choice(TRANSCRIBE_PROMPTS), text)
+
+    def _make_messages(self, num_audio_tokens: int, prompt: str, response: str) -> dict:
+        user_content = ("<audio>" * num_audio_tokens) + " " + prompt
+        messages = []
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": user_content})
+        messages.append({"role": "assistant", "content": response})
+        return {"messages": messages}
+
+    def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
+        audio_arrays, valid_features = self._extract_audio_arrays(features)
 
         audio_out = self.feature_extractor(
             audio_arrays,
@@ -233,46 +224,24 @@ class DataCollator:
             return_tensors="pt",
         )
 
-        # Compute per-sample audio token counts (like GlmAsr)
-        mel_lengths = audio_out.attention_mask.sum(dim=-1)  # Per-sample mel lengths
-        audio_token_counts = []
-        for mel_len in mel_lengths:
-            encoder_len = self._compute_encoder_output_length(int(mel_len.item()))
-            num_tokens = self.projector.get_output_length(encoder_len)
-            audio_token_counts.append(num_tokens)
+        mel_lengths = audio_out.attention_mask.sum(dim=-1)
+        audio_token_counts = [
+            self.projector.get_output_length(self._compute_encoder_output_length(int(m.item())))
+            for m in mel_lengths
+        ]
 
-        # Lowercase all training texts
-        processed_texts = [(f.get("text") or "").strip().lower() for f in valid_features]
+        text_features = [
+            self._build_sample(f, n) for f, n in zip(valid_features, audio_token_counts)
+        ]
 
-        # Build messages for each sample with per-sample audio token counts
-        text_features = []
-        for text, num_audio_tokens in zip(processed_texts, audio_token_counts):
-            audio_placeholder = "<audio>" * num_audio_tokens
-            prompt = random.choice(TRANSCRIBE_PROMPTS)
-            user_content = audio_placeholder + " " + prompt
-
-            messages = []
-            if self.system_prompt:
-                messages.append({"role": "system", "content": self.system_prompt})
-            messages.append({"role": "user", "content": user_content})
-            messages.append({"role": "assistant", "content": text})
-
-            text_features.append({"messages": messages})
-
-        # Let trl handle tokenization, label masking, and padding
         batch = self.text_collator(text_features)
         batch["input_features"] = audio_out.input_features
         batch["audio_attention_mask"] = audio_out.attention_mask
-
         return batch
 
 
-# SIFT configuration for multi-task training
-SIFT_SYSTEM_MESSAGE = ""  # No system message
-
-
 class MultiTaskDataCollator(DataCollator):
-    """Collates audio and text data for multi-task training."""
+    """Collates audio and text data for multi-task ASR + SIFT training."""
 
     def __init__(
         self,
@@ -286,81 +255,19 @@ class MultiTaskDataCollator(DataCollator):
             tokenizer=tokenizer,
             feature_extractor=feature_extractor,
             sample_rate=sample_rate,
-            system_prompt=SIFT_SYSTEM_MESSAGE,
+            system_prompt="",
             projector=projector,
             encoder_conv_layers=encoder_conv_layers,
         )
 
-    def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
-        # Process audio
-        audio_arrays = []
-        valid_features = []
-        for f in features:
-            try:
-                audio = f["audio"]["array"]
-                if hasattr(audio, "numpy"):
-                    audio = audio.numpy()
-                audio = audio.squeeze()
-                if audio.ndim > 1:
-                    audio = audio.mean(axis=0)
-                audio_arrays.append(audio)
-                valid_features.append(f)
-            except Exception:
-                continue
-            finally:
-                f["audio"] = None
-
-        if not audio_arrays:
-            raise ValueError("No valid audio samples in batch")
-
-        audio_out = self.feature_extractor(
-            audio_arrays,
-            sampling_rate=self.sample_rate,
-            padding=self._audio_padding,
-            return_attention_mask=True,
-            return_tensors="pt",
-        )
-
-        # Compute per-sample audio token counts
-        mel_lengths = audio_out.attention_mask.sum(dim=-1)
-        audio_token_counts = []
-        for mel_len in mel_lengths:
-            encoder_len = self._compute_encoder_output_length(int(mel_len.item()))
-            num_tokens = self.projector.get_output_length(encoder_len)
-            audio_token_counts.append(num_tokens)
-
-        # Build messages - differentiate between ASR and SIFT tasks using task column
-        text_features = []
-        for f, num_audio_tokens in zip(valid_features, audio_token_counts):
-            audio_placeholder = "<audio>" * num_audio_tokens
-            task = f.get("task", "transcribe")
-
-            if task == "sift":
-                # SIFT task: describe audio
-                response = (f.get("sift_response") or f.get("text") or "").strip()
-                prompt = random.choice(DESCRIBE_PROMPTS)
-            else:
-                # ASR task: transcription
-                response = (f.get("text") or "").strip().lower()
-                prompt = random.choice(TRANSCRIBE_PROMPTS)
-
-            user_content = f"{audio_placeholder} {prompt}"
-
-            # Build messages (skip system if empty)
-            messages = []
-            if self.system_prompt:
-                messages.append({"role": "system", "content": self.system_prompt})
-            messages.append({"role": "user", "content": user_content})
-            messages.append({"role": "assistant", "content": response})
-
-            text_features.append({"messages": messages})
-
-        # Let trl handle tokenization, label masking, and padding
-        batch = self.text_collator(text_features)
-        batch["input_features"] = audio_out.input_features
-        batch["audio_attention_mask"] = audio_out.attention_mask
-
-        return batch
+    def _build_sample(self, feature: dict, num_audio_tokens: int) -> dict:
+        if feature.get("task") == "sift":
+            response = (feature.get("sift_response") or feature.get("text") or "").strip()
+            prompt = random.choice(DESCRIBE_PROMPTS)
+        else:
+            response = (feature.get("text") or "").strip().lower()
+            prompt = random.choice(TRANSCRIBE_PROMPTS)
+        return self._make_messages(num_audio_tokens, prompt, response)
 
 
 class ASRTrainer(Trainer):
@@ -374,18 +281,14 @@ class ASRTrainer(Trainer):
         it incorrectly uses shift_labels=False, causing misaligned predictions.
         This override forces shift_labels=True for correct causal LM behavior.
         """
-        # Pop labels if using label smoothing (matches Trainer behavior)
-        if self.label_smoother is not None and "labels" in inputs:
-            labels = inputs.pop("labels")
-        else:
-            labels = None
+        labels = (
+            inputs.pop("labels") if self.label_smoother is not None and "labels" in inputs else None
+        )
 
         outputs = model(**inputs)
 
         if labels is not None:
-            # Force shift_labels=True since ASRModel is a causal LM
             loss = self.label_smoother(outputs, labels, shift_labels=True)
-            # Scale loss for gradient accumulation (Trainer expects this)
             if self.args.gradient_accumulation_steps > 1:
                 loss = loss / self.args.gradient_accumulation_steps
         else:
@@ -421,53 +324,46 @@ def get_valid_training_args(config: dict) -> dict:
     return {k: v for k, v in config.items() if k in valid_fields}
 
 
+TRAINING_MODEL_PARAMS = [
+    "label_smoothing",
+    "projector_dropout",
+    "use_specaugment",
+    "num_time_masks",
+    "time_mask_length",
+    "num_freq_masks",
+    "freq_mask_length",
+    "attn_implementation",
+    "use_lora",
+    "lora_rank",
+    "lora_alpha",
+    "lora_dropout",
+    "lora_target_modules",
+    "freeze_projector",
+]
+
+
 @hydra.main(version_base=None, config_path="../configs", config_name="config")
 def main(cfg: DictConfig) -> None:
-    # Check HF_TOKEN is set if pushing to hub
-    if cfg.training.get("push_to_hub") and cfg.training.get("hub_model_id"):
-        import os
+    push_to_hub = cfg.training.get("push_to_hub") and cfg.training.get("hub_model_id")
+    if push_to_hub and not os.environ.get("HF_TOKEN"):
+        raise ValueError(
+            "HF_TOKEN environment variable is required when push_to_hub is enabled. "
+            "Set it with: export HF_TOKEN=your_token"
+        )
 
-        if not os.environ.get("HF_TOKEN"):
-            raise ValueError(
-                "HF_TOKEN environment variable is required when push_to_hub is enabled. "
-                "Set it with: export HF_TOKEN=your_token"
-            )
-
-    # Initialize wandb
     if cfg.training.get("report_to") == "wandb":
         wandb.init(
             project=cfg.training.get("wandb_project", "tiny-audio"),
             config=OmegaConf.to_container(cfg, resolve=True),
         )
 
-    # Create model config from hydra config
-    # Merge model config with training config for model-specific params
     model_config_dict = OmegaConf.to_container(cfg.model, resolve=True)
     assert isinstance(model_config_dict, dict), "model config must be a dict"
-    # Add training params that affect model behavior
-    training_model_params = [
-        "label_smoothing",
-        "projector_dropout",
-        "use_specaugment",
-        "num_time_masks",
-        "time_mask_length",
-        "num_freq_masks",
-        "freq_mask_length",
-        "attn_implementation",
-        # LoRA params (Stage 2 fine-tuning)
-        "use_lora",
-        "lora_rank",
-        "lora_alpha",
-        "lora_dropout",
-        "lora_target_modules",
-        "freeze_projector",
-    ]
-    for param in training_model_params:
+    for param in TRAINING_MODEL_PARAMS:
         if cfg.training.get(param) is not None:
             model_config_dict[param] = cfg.training[param]
     asr_config = ASRConfig(**model_config_dict)
 
-    # Load or create model
     if cfg.model.get("pretrained_model_path"):
         model = ASRModel.from_pretrained(cfg.model.pretrained_model_path, config=asr_config)
     else:
@@ -475,27 +371,21 @@ def main(cfg: DictConfig) -> None:
 
     model.config.use_cache = False
 
-    # Store hub_model_id in config so save_pretrained() can set base_model_name_or_path correctly
     if hub_model_id := cfg.training.get("hub_model_id"):
         model.config.pretrained_model_path = hub_model_id
 
-    # Disable Qwen3 thinking mode by patching the chat template
-    # This is a workaround for TRL's DataCollatorForChatML not passing enable_thinking=False
-    # See: https://github.com/huggingface/trl/issues/3387
+    # Workaround: TRL's DataCollatorForChatML doesn't pass enable_thinking=False to Qwen3.
+    # See https://github.com/huggingface/trl/issues/3387
     if model.tokenizer.chat_template and "enable_thinking" in model.tokenizer.chat_template:
-        # Replace the conditional check with a hardcoded False
         model.tokenizer.chat_template = model.tokenizer.chat_template.replace(
             "enable_thinking is defined and enable_thinking is false",
-            "true",  # Always disable thinking
+            "true",
         )
 
-    # Check if multi-task training is enabled
     multitask_enabled = cfg.get("multitask", {}).get("enabled", False)
 
-    # Load datasets
     train_dataset, val_dataset = DatasetLoader(cfg, multitask_enabled=multitask_enabled).load()
 
-    # Create data collator (multi-task or standard)
     if multitask_enabled:
         data_collator = MultiTaskDataCollator(
             tokenizer=model.tokenizer,
@@ -514,7 +404,6 @@ def main(cfg: DictConfig) -> None:
             encoder_conv_layers=model.config.encoder_conv_layers,
         )
 
-    # Setup callbacks
     callbacks = []
     if cfg.early_stopping.patience:
         callbacks.append(
@@ -523,10 +412,9 @@ def main(cfg: DictConfig) -> None:
                 early_stopping_threshold=cfg.early_stopping.threshold,
             )
         )
-    if cfg.training.get("push_to_hub") and cfg.training.get("hub_model_id"):
+    if push_to_hub:
         callbacks.append(PushToHubCallback())
 
-    # Configure torch.compile if specified
     training_config = OmegaConf.to_container(cfg.training, resolve=True)
     assert isinstance(training_config, dict)
     if compile_config := training_config.pop("torch_compile_config", None):
@@ -536,11 +424,9 @@ def main(cfg: DictConfig) -> None:
         )
         torch._inductor.config.compile_threads = compile_config.get("compile_threads", 4)
 
-    # Create trainer with only valid TrainingArguments
-    valid_args = get_valid_training_args(training_config)
     trainer = ASRTrainer(
         model=model,
-        args=TrainingArguments(**valid_args),
+        args=TrainingArguments(**get_valid_training_args(training_config)),
         train_dataset=train_dataset,
         eval_dataset=val_dataset,
         data_collator=data_collator,
@@ -550,8 +436,7 @@ def main(cfg: DictConfig) -> None:
     trainer.train(resume_from_checkpoint=cfg.training.get("resume_from_checkpoint"))
     trainer.save_model()
 
-    if cfg.training.get("push_to_hub") and cfg.training.get("hub_model_id"):
-        # Use model's push_to_hub which properly sets base_model_name_or_path in adapter_config.json
+    if push_to_hub:
         trainer.model.push_to_hub(
             cfg.training.hub_model_id,
             commit_message="Training complete - final model",

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -45,30 +45,12 @@ def parse_results_file(results_path: Path) -> list[dict]:
 def _extract_model_from_dir(dir_name: str) -> str:
     """Extract model name from directory name.
 
-    Format: {timestamp}_{model}_{dataset}[_suffix]
-    Returns the model portion, handling multi-part model names.
+    Format: {timestamp_date}_{timestamp_time}_{model}_{dataset}[_suffix]
     """
     parts = dir_name.split("_")
     if len(parts) < 3:
         return dir_name
-
-    # Skip timestamp (first 2 parts: date + time)
-    # Last part(s) are dataset + optional suffix (diarization, alignment)
-    # Everything in between is the model name
-    suffix_parts = {"diarization", "alignment"}
-    end_idx = len(parts)
-
-    # Remove suffix if present
-    if parts[-1] in suffix_parts:
-        end_idx -= 1
-
-    # The part before suffix/end is the dataset, everything between timestamp and dataset is model
-    # Format: YYYYMMDD_HHMMSS_model_dataset or YYYYMMDD_HHMMSS_model-name_dataset
-    if end_idx >= 3:
-        # Model is at index 2 (after date_time)
-        return parts[2]
-
-    return dir_name
+    return parts[2]
 
 
 def find_model_dirs(
@@ -88,12 +70,11 @@ def find_model_dirs(
     Returns:
         Sorted list of matching directory paths.
     """
-    exclude = [ex for ex in (exclude or []) if ex]  # Filter out empty strings
+    exclude = [ex for ex in (exclude or []) if ex]
     dirs = []
     for d in outputs_dir.iterdir():
         if not d.is_dir():
             continue
-        # Extract model name from directory and match exactly
         model_name = _extract_model_from_dir(d.name)
         if model_name.lower() == model_pattern.lower() and not any(
             ex.lower() in d.name.lower() for ex in exclude
@@ -101,13 +82,11 @@ def find_model_dirs(
             dirs.append(d)
 
     if latest:
-        # Group by dataset and keep only most recent (dirs are sorted by timestamp in name)
         latest_by_dataset: dict[str, Path] = {}
-        for d in sorted(dirs, reverse=True):  # Sort descending by name (timestamp first)
-            # Extract dataset from dir name: <timestamp>_<model>_<dataset>
+        for d in sorted(dirs, reverse=True):
             parts = d.name.split("_")
             if len(parts) >= 3:
-                dataset = parts[-1]  # Last part is dataset
+                dataset = parts[-1]
                 if dataset not in latest_by_dataset:
                     latest_by_dataset[dataset] = d
         dirs = list(latest_by_dataset.values())

--- a/tests/test_asr_processing.py
+++ b/tests/test_asr_processing.py
@@ -13,10 +13,10 @@ class TestComputeEncoderOutputLength:
     @pytest.fixture
     def processor_method(self):
         """Get the method without creating full processor."""
-        from tiny_audio.asr_processing import ASRProcessor
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
 
         class MockProcessor:
-            encoder_conv_layers = ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+            encoder_conv_layers = DEFAULT_ENCODER_CONV_LAYERS
 
             def _compute_encoder_output_length(self, mel_length: int) -> int:
                 length = mel_length
@@ -64,10 +64,10 @@ class TestProcessorConstants:
 
     def test_default_conv_layers(self):
         """DEFAULT_ENCODER_CONV_LAYERS should match Whisper."""
-        from tiny_audio.asr_processing import ASRProcessor
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
 
         expected = [(1, 3, 1), (1, 3, 2)]
-        assert expected == ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+        assert expected == DEFAULT_ENCODER_CONV_LAYERS
 
 
 class TestProcessorInit:
@@ -88,11 +88,12 @@ class TestProcessorInit:
         self, mock_feature_extractor, mock_tokenizer, mock_projector
     ):
         """Should use default conv layers when not specified."""
+        from tiny_audio.asr_config import DEFAULT_ENCODER_CONV_LAYERS
         from tiny_audio.asr_processing import ASRProcessor
 
         processor = ASRProcessor(mock_feature_extractor, mock_tokenizer, mock_projector)
 
-        assert processor.encoder_conv_layers == ASRProcessor.DEFAULT_ENCODER_CONV_LAYERS
+        assert processor.encoder_conv_layers == DEFAULT_ENCODER_CONV_LAYERS
 
     def test_init_accepts_custom_conv_layers(
         self, mock_feature_extractor, mock_tokenizer, mock_projector

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -4,35 +4,6 @@ import pytest
 import torch
 
 
-class TestIsFlashAttnAvailable:
-    """Tests for EndpointHandler._is_flash_attn_available."""
-
-    def test_returns_bool(self):
-        """Should return a boolean."""
-        from tiny_audio.handler import EndpointHandler
-
-        handler = object.__new__(EndpointHandler)
-        result = handler._is_flash_attn_available()
-
-        assert isinstance(result, bool)
-
-    def test_checks_flash_attn_module(self, mocker):
-        """Should check for flash_attn module."""
-        from tiny_audio.handler import EndpointHandler
-
-        handler = object.__new__(EndpointHandler)
-        mock_find = mocker.patch("importlib.util.find_spec")
-
-        # Test when flash_attn is available
-        mock_find.return_value = True
-        assert handler._is_flash_attn_available() is True
-        mock_find.assert_called_with("flash_attn")
-
-        # Test when flash_attn is not available
-        mock_find.return_value = None
-        assert handler._is_flash_attn_available() is False
-
-
 class TestEndpointHandlerCall:
     """Tests for EndpointHandler.__call__ method."""
 

--- a/tiny_audio/alignment.py
+++ b/tiny_audio/alignment.py
@@ -120,15 +120,18 @@ class ForcedAligner:
 
             if move_score >= stay_score:
                 # Token j-1 was emitted at frame t-1
-                token_frames[j - 1].insert(0, t - 1)
+                token_frames[j - 1].append(t - 1)
                 j -= 1
-            # Always decrement time (monotonic)
             t -= 1
 
         # Handle any remaining tokens at the start (edge case)
         while j > 0:
-            token_frames[j - 1].insert(0, 0)
+            token_frames[j - 1].append(0)
             j -= 1
+
+        # We appended in reverse-time order; restore monotonic order
+        for frames in token_frames:
+            frames.reverse()
 
         # Convert to spans
         token_spans: list[tuple[int, float, float]] = []

--- a/tiny_audio/asr_config.py
+++ b/tiny_audio/asr_config.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import transformers
 
+# Default conv layers for Whisper/GLM-ASR audio encoders: [(pad, kernel, stride), ...]
+DEFAULT_ENCODER_CONV_LAYERS = [(1, 3, 1), (1, 3, 2)]
+
 
 class ASRConfig(transformers.PretrainedConfig):
     """Configuration class for the ASR model.
@@ -107,8 +110,7 @@ class ASRConfig(transformers.PretrainedConfig):
         self.system_prompt = system_prompt
         self.encoder_dim = encoder_dim
         self.llm_dim = llm_dim
-        # Default conv layers for Whisper/GLM-ASR: [(pad, kernel, stride), ...]
-        self.encoder_conv_layers = encoder_conv_layers or [(1, 3, 1), (1, 3, 2)]
+        self.encoder_conv_layers = encoder_conv_layers or DEFAULT_ENCODER_CONV_LAYERS
         self.audio_sample_rate = audio_sample_rate
         self.projector_init_std = projector_init_std
         self.projector_pool_stride = projector_pool_stride
@@ -151,28 +153,18 @@ class ASRConfig(transformers.PretrainedConfig):
         ]
         self.freeze_projector = freeze_projector
 
-        # Generation parameters (use explicit value if provided, else use default)
-        self.num_beams = num_beams if num_beams is not None else generation_defaults["num_beams"]
-        self.max_new_tokens = (
-            max_new_tokens if max_new_tokens is not None else generation_defaults["max_new_tokens"]
-        )
-        self.min_new_tokens = (
-            min_new_tokens if min_new_tokens is not None else generation_defaults["min_new_tokens"]
-        )
-        self.repetition_penalty = (
-            repetition_penalty
-            if repetition_penalty is not None
-            else generation_defaults["repetition_penalty"]
-        )
-        self.length_penalty = (
-            length_penalty if length_penalty is not None else generation_defaults["length_penalty"]
-        )
-        self.no_repeat_ngram_size = (
-            no_repeat_ngram_size
-            if no_repeat_ngram_size is not None
-            else generation_defaults["no_repeat_ngram_size"]
-        )
-        self.use_cache = use_cache if use_cache is not None else generation_defaults["use_cache"]
+        explicit_generation_args = {
+            "num_beams": num_beams,
+            "max_new_tokens": max_new_tokens,
+            "min_new_tokens": min_new_tokens,
+            "repetition_penalty": repetition_penalty,
+            "length_penalty": length_penalty,
+            "no_repeat_ngram_size": no_repeat_ngram_size,
+            "use_cache": use_cache,
+        }
+        for key, default in generation_defaults.items():
+            value = explicit_generation_args[key]
+            setattr(self, key, value if value is not None else default)
         self.do_sample = do_sample
         self.temperature = temperature
         self.top_p = top_p

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -747,57 +747,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
 
         thread.join()
 
-    @torch.no_grad()
-    def generate_text_only(
-        self,
-        messages: list[dict[str, str]],
-        max_new_tokens: int = 256,
-        **generate_kwargs,
-    ) -> str:
-        """Generate text using only the LLM (no audio encoding).
-
-        Used for SIFT-style response generation from metadata prompts.
-
-        Args:
-            messages: List of chat messages [{"role": "user", "content": "..."}]
-            max_new_tokens: Maximum tokens to generate
-            **generate_kwargs: Additional generation arguments
-
-        Returns:
-            Generated text response
-        """
-        device = next(self.language_model.parameters()).device
-
-        # Apply chat template
-        input_ids = self.tokenizer.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=True,
-            return_tensors="pt",
-            enable_thinking=False,  # Disable Qwen3 thinking mode for ASR
-        ).to(device)
-
-        if input_ids.dim() == 1:
-            input_ids = input_ids.unsqueeze(0)
-
-        attention_mask = torch.ones_like(input_ids)
-
-        # Generate using language model directly
-        output = self.language_model.generate(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            max_new_tokens=max_new_tokens,
-            do_sample=False,
-            pad_token_id=self.tokenizer.pad_token_id,
-            eos_token_id=self.tokenizer.eos_token_id,
-            **generate_kwargs,
-        )
-
-        # Decode only the new tokens
-        new_tokens = output[0, input_ids.shape[1] :]
-        response = self.tokenizer.decode(new_tokens, skip_special_tokens=True)
-        return response.strip()
-
     def save_pretrained(self, save_directory: Union[str, Path], **kwargs) -> None:
         """Save model, tokenizer, and processor."""
         import shutil
@@ -895,10 +844,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
         self.config.pretrained_model_path = repo_id
         # Call parent's push_to_hub
         return super().push_to_hub(repo_id, **kwargs)
-
-    def create_or_update_model_card(self, output_dir: Union[str, Path]) -> None:
-        """No-op for model card creation - we use MODEL_CARD.md in repo instead."""
-        pass
 
 
 # Register with transformers Auto classes

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -6,7 +6,6 @@ from typing import Iterator, Optional, Union
 import torch
 import torch.nn as nn
 from transformers import (
-    AutoConfig,
     AutoModel,
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -482,8 +481,8 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             if self.training and self.spec_augment is not None:
                 input_features = self.spec_augment(input_features)
 
-            # Count expected audio tokens from input_ids (ground truth from collator)
-            audio_token_counts = (input_ids == self.audio_token_id).sum(dim=-1)
+            is_audio_token = input_ids == self.audio_token_id
+            audio_token_counts = is_audio_token.sum(dim=-1)
 
             # Encode audio -> flattened (total_audio_tokens, hidden_dim)
             audio_embeds = self._encode_audio(
@@ -491,7 +490,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             )
 
             # Replace <audio> token placeholders with audio embeddings using masked_scatter
-            audio_token_mask = (input_ids == self.audio_token_id).unsqueeze(-1)
+            audio_token_mask = is_audio_token.unsqueeze(-1)
             inputs_embeds = inputs_embeds.masked_scatter(
                 audio_token_mask.to(inputs_embeds.device),
                 audio_embeds.to(inputs_embeds.device, dtype=inputs_embeds.dtype),
@@ -750,9 +749,8 @@ class ASRModel(PreTrainedModel, GenerationMixin):
     def save_pretrained(self, save_directory: Union[str, Path], **kwargs) -> None:
         """Save model, tokenizer, and processor."""
         import shutil
-        from pathlib import Path as PathlibPath
 
-        save_dir = PathlibPath(save_directory)
+        save_dir = Path(save_directory)
         save_dir.mkdir(parents=True, exist_ok=True)
 
         # Update config with actual vocab size
@@ -823,7 +821,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             json.dump(processor_config, f, indent=2)
 
         # Copy source files for auto-loading
-        src_dir = PathlibPath(__file__).parent
+        src_dir = Path(__file__).parent
         for asr_file in src_dir.glob("asr_*.py"):
             shutil.copy(asr_file, save_dir / asr_file.name)
         # Copy projectors module
@@ -847,5 +845,5 @@ class ASRModel(PreTrainedModel, GenerationMixin):
 
 
 # Register with transformers Auto classes
-AutoConfig.register("asr_model", ASRConfig)
+# (AutoConfig.register is handled in asr_config.py at module load.)
 AutoModel.register(ASRConfig, ASRModel)

--- a/tiny_audio/asr_pipeline.py
+++ b/tiny_audio/asr_pipeline.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 import torch
 import transformers
+from transformers.pipelines.audio_utils import ffmpeg_read
 
 try:
     from .alignment import ForcedAligner
@@ -19,6 +20,13 @@ except ImportError:
 
 # Re-export for backwards compatibility
 __all__ = ["ForcedAligner", "SpeakerDiarizer", "ASRPipeline"]
+
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>\s*", flags=re.DOTALL)
+_DEFAULT_MIN_REPEATS = 3
+_TRAILING_CHAR_RE = re.compile(r"(.)\1{" + str(_DEFAULT_MIN_REPEATS - 1) + r",}$")
+_TRAILING_WORD_RE = re.compile(
+    r"\b(\w+)(?:\s+\1){" + str(_DEFAULT_MIN_REPEATS - 1) + r",}\s*$", re.IGNORECASE
+)
 
 
 class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
@@ -152,8 +160,6 @@ class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
 
     def _extract_audio(self, inputs) -> dict | None:
         """Extract audio array from various input formats using HF utilities."""
-        from transformers.pipelines.audio_utils import ffmpeg_read
-
         if isinstance(inputs, dict):
             if "array" in inputs:
                 return {
@@ -257,8 +263,8 @@ class ASRPipeline(transformers.AutomaticSpeechRecognitionPipeline):
 
         text = self.tokenizer.decode(tokens, skip_special_tokens=True).strip()
         # Strip <think>...</think> tags (Qwen3 doesn't respect /no_think prompt)
-        text = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
-        # Truncate repetitions at end of text
+        if "<think>" in text:
+            text = _THINK_TAG_RE.sub("", text).strip()
         text = _truncate_repetitions(text)
         return {"text": text}
 
@@ -281,14 +287,16 @@ def _truncate_repetitions(text: str, min_repeats: int = 3) -> str:
     if not text:
         return text
 
-    # 1. Truncate repeated characters at end (e.g., "444444" -> "4")
-    char_pattern = re.compile(r"(.)\1{" + str(min_repeats - 1) + r",}$")
-    text = char_pattern.sub(r"\1", text)
+    if min_repeats == _DEFAULT_MIN_REPEATS:
+        char_pattern = _TRAILING_CHAR_RE
+        word_pattern = _TRAILING_WORD_RE
+    else:
+        char_pattern = re.compile(r"(.)\1{" + str(min_repeats - 1) + r",}$")
+        word_pattern = re.compile(
+            r"\b(\w+)(?:\s+\1){" + str(min_repeats - 1) + r",}\s*$", re.IGNORECASE
+        )
 
-    # 2. Truncate repeated words at end (e.g., "the the the" -> "the")
-    word_pattern = re.compile(
-        r"\b(\w+)(?:\s+\1){" + str(min_repeats - 1) + r",}\s*$", re.IGNORECASE
-    )
+    text = char_pattern.sub(r"\1", text)
     while word_pattern.search(text):
         text = word_pattern.sub(r"\1", text)
 

--- a/tiny_audio/asr_processing.py
+++ b/tiny_audio/asr_processing.py
@@ -5,9 +5,9 @@ import transformers
 from transformers import ProcessorMixin
 
 try:
-    from .asr_config import ASRConfig
+    from .asr_config import DEFAULT_ENCODER_CONV_LAYERS, ASRConfig
 except ImportError:
-    from asr_config import ASRConfig  # type: ignore[no-redef]
+    from asr_config import DEFAULT_ENCODER_CONV_LAYERS, ASRConfig  # type: ignore[no-redef]
 
 
 class ASRProcessor(ProcessorMixin):
@@ -18,8 +18,6 @@ class ASRProcessor(ProcessorMixin):
     tokenizer_class = "AutoTokenizer"
     AUDIO_TOKEN = "<audio>"
     TRANSCRIBE_PROMPT = ""
-    # Default conv layers for Whisper/GLM-ASR: [(pad, kernel, stride), ...]
-    DEFAULT_ENCODER_CONV_LAYERS = [(1, 3, 1), (1, 3, 2)]
 
     def __init__(
         self,
@@ -40,7 +38,7 @@ class ASRProcessor(ProcessorMixin):
         self.tokenizer = tokenizer
         self.audio_token_id = tokenizer.convert_tokens_to_ids(self.AUDIO_TOKEN)
         self.projector = projector
-        self.encoder_conv_layers = encoder_conv_layers or self.DEFAULT_ENCODER_CONV_LAYERS
+        self.encoder_conv_layers = encoder_conv_layers or DEFAULT_ENCODER_CONV_LAYERS
 
     def _compute_encoder_output_length(self, mel_length: int) -> int:
         """Compute encoder output length using conv layer formulas."""

--- a/tiny_audio/diarization.py
+++ b/tiny_audio/diarization.py
@@ -154,8 +154,6 @@ class SpeakerClusterer:
         Returns:
             Cluster labels of shape [N]
         """
-        import warnings
-
         if len(embeddings.shape) != 2:
             raise ValueError(f"Expected 2D array, got shape {embeddings.shape}")
 

--- a/tiny_audio/handler.py
+++ b/tiny_audio/handler.py
@@ -28,39 +28,29 @@ class EndpointHandler:
         import os
 
         import nltk
+        from transformers.utils import is_flash_attn_2_available
 
         nltk.download("punkt_tab", quiet=True)
 
         os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
-        # Prepare model kwargs - let transformers handle device placement
         model_kwargs = {
             "device_map": "auto",
             "torch_dtype": "auto",
             "low_cpu_mem_usage": True,
         }
-        if self._is_flash_attn_available():
+        if is_flash_attn_2_available():
             model_kwargs["attn_implementation"] = "flash_attention_2"
 
-        # Load model (this loads the model, tokenizer, and feature extractor)
         self.model = ASRModel.from_pretrained(path, **model_kwargs)
-
-        # Get device from model for pipeline
         self.device = next(self.model.parameters()).device
 
-        # Instantiate custom pipeline - it will get feature_extractor and tokenizer from model
         self.pipe = ASRPipeline(
             model=self.model,
             feature_extractor=self.model.feature_extractor,
             tokenizer=self.model.tokenizer,
             device=self.device,
         )
-
-    def _is_flash_attn_available(self):
-        """Check if flash attention is available."""
-        import importlib.util
-
-        return importlib.util.find_spec("flash_attn") is not None
 
     def __call__(self, data: Dict[str, Any]) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Process an inference request.

--- a/tiny_audio/integrations/pipecat_stt.py
+++ b/tiny_audio/integrations/pipecat_stt.py
@@ -3,6 +3,7 @@
 from typing import Optional
 
 import numpy as np
+import torch
 
 try:
     from pipecat.frames.frames import (
@@ -46,6 +47,7 @@ class TinyAudioSTTService(SegmentedSTTService):
     ):
         super().__init__(**kwargs)
         self._model = None
+        self._model_dtype: Optional[torch.dtype] = None
         self._model_id = model_id
         self._streaming = streaming
         self._device = device
@@ -53,8 +55,6 @@ class TinyAudioSTTService(SegmentedSTTService):
     def _ensure_model(self):
         """Lazy-load the model on first use."""
         if self._model is None:
-            import torch
-
             try:
                 from tiny_audio import ASRModel  # pyright: ignore[reportMissingImports]
             except ImportError:
@@ -76,10 +76,10 @@ class TinyAudioSTTService(SegmentedSTTService):
                 else:
                     self._device = torch.device("cpu")
 
-            # Load model and move to device
             self._model = ASRModel.from_pretrained(self._model_id)
             self._model.to(self._device)
             self._model.eval()
+            self._model_dtype = next(self._model.parameters()).dtype
 
     async def run_stt(self, audio: bytes):
         """Transcribe audio segment, yielding interim results if streaming enabled.
@@ -101,9 +101,6 @@ class TinyAudioSTTService(SegmentedSTTService):
             yield TranscriptionFrame(text="", user_id=self._user_id, timestamp="")
             return
 
-        # Preprocess audio through feature extractor
-        import torch
-
         inputs = self._model.feature_extractor(
             audio_array,
             sampling_rate=16000,
@@ -111,9 +108,7 @@ class TinyAudioSTTService(SegmentedSTTService):
             return_attention_mask=True,
         )
 
-        # Get model dtype and cast inputs to match
-        model_dtype = next(self._model.parameters()).dtype
-        input_features = inputs.input_features.to(self._device, dtype=model_dtype)
+        input_features = inputs.input_features.to(self._device, dtype=self._model_dtype)
         attention_mask = inputs.attention_mask.to(self._device)
 
         if self._streaming:

--- a/tiny_audio/projectors.py
+++ b/tiny_audio/projectors.py
@@ -89,34 +89,6 @@ class SimpleAdapter(nn.Module):
         return self.fc2(self.act(self.fc1(x)))
 
 
-class SwiGLU(nn.Module):
-    """SwiGLU activation with gated linear units (used in LLaMA, Mistral, etc.)."""
-
-    def __init__(self, dim: int, hidden_dim: int, bias: bool = False):
-        super().__init__()
-        self.w1 = nn.Linear(dim, hidden_dim, bias=bias)  # Gate
-        self.w2 = nn.Linear(dim, hidden_dim, bias=bias)  # Value
-        self.w3 = nn.Linear(hidden_dim, dim, bias=bias)  # Output
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w3(F.silu(self.w1(x)) * self.w2(x))
-
-
-class AsymmetricSwiGLU(nn.Module):
-    """SwiGLU that handles different input and output dimensions."""
-
-    def __init__(
-        self, in_features: int, hidden_features: int, out_features: int, bias: bool = False
-    ):
-        super().__init__()
-        self.w1 = nn.Linear(in_features, hidden_features, bias=bias)  # Gate
-        self.w2 = nn.Linear(in_features, hidden_features, bias=bias)  # Value
-        self.w3 = nn.Linear(hidden_features, out_features, bias=bias)  # Output
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w3(F.silu(self.w1(x)) * self.w2(x))
-
-
 class MOSAProjector(nn.Module):
     """MOSA-Base projector: simple 2-layer ReLU router with 4 simple adapters.
 

--- a/tiny_audio/projectors.py
+++ b/tiny_audio/projectors.py
@@ -58,13 +58,7 @@ class MLPAudioProjector(nn.Module):
         Returns:
             Projected features of shape [batch, (seq_len - k) // k + 1, llm_dim]
         """
-        batch, seq, dim = x.shape
-        # Truncate to match GLM-ASR: use (seq - k) // k + 1 frames
-        # This drops trailing frames that don't fill a complete k-frame window
-        out_len = (seq - self.k) // self.k + 1
-        x = x[:, : out_len * self.k, :]  # Truncate to exact multiple
-        x = x.reshape(batch, out_len, dim * self.k)
-
+        x = _frame_stack(x, self.k)
         x = self.linear_1(x)
         x = self.norm(x)
         x = self.act(x)
@@ -74,6 +68,17 @@ class MLPAudioProjector(nn.Module):
 # =============================================================================
 # MoE Projector (MOSA-style)
 # =============================================================================
+
+
+def _frame_stack(x: torch.Tensor, k: int) -> torch.Tensor:
+    """Stack k adjacent frames along the feature dim.
+
+    Truncates trailing frames that don't fill a complete k-frame window,
+    matching GLM-ASR's `(seq_len - k) // k + 1` formula.
+    """
+    batch, seq, dim = x.shape
+    out_len = (seq - k) // k + 1
+    return x[:, : out_len * k, :].reshape(batch, out_len, dim * k)
 
 
 class SimpleAdapter(nn.Module):
@@ -253,13 +258,10 @@ class MoEAudioProjector(nn.Module):
         Returns:
             Projected features of shape [batch, out_len, llm_dim]
         """
-        # 1. Frame Stacking
-        batch, seq, dim = x.shape
-        out_len = (seq - self.k) // self.k + 1
-        x = x[:, : out_len * self.k, :]
-        x = x.reshape(batch, out_len, dim * self.k)
+        x = _frame_stack(x, self.k)
+        batch, out_len, _ = x.shape
 
-        # 2. Normalize stacked input (like main branch SharedMoEBlock)
+        # Normalize stacked input (like main branch SharedMoEBlock)
         x = self.norm(x)
         flat_x = x.view(-1, x.size(-1))  # [tokens, in_dim]
 


### PR DESCRIPTION
## Summary

Three commits of behavior-preserving simplification across the repo, surfaced by parallel code-reuse / code-quality / efficiency reviews. Total: **~1020 lines removed**, 281 tests pass.

- **Remove dead code** (`d9c94ba`): drop unused `SwiGLU` / `AsymmetricSwiGLU` projector classes, the never-called `generate_text_only` ASR method, and the no-op `create_or_update_model_card` stub.
- **Simplify `tiny_audio/`** (`c285c42`): hoist `DEFAULT_ENCODER_CONV_LAYERS` into `asr_config.py`; remove duplicate `AutoConfig.register` call; replace hand-rolled `_is_flash_attn_available` with `transformers.utils.is_flash_attn_2_available`; extract `_frame_stack` helper shared by MLP/MoE projectors; collapse 7 repetitive None-default assignments in `ASRConfig.__init__` into a dict-driven loop. Efficiency: hoist 3 regex compiles to module level, add `<think>`-tag fast path, replace O(n²) `list.insert(0, ...)` in alignment Viterbi with append+reverse, cache `_model_dtype` in pipecat streaming path.
- **Simplify `scripts/`** (`3726101`): unify the `MultiTaskDataCollator` copy-paste of `__call__` into a `_build_sample` hook on `DataCollator`; consolidate 5 `save_*_results` writers + 7 API-key checks in `eval/cli.py`; share sequential/parallel evaluation paths in `evaluators/{base,mcq,classification}`; consolidate 3 RunPod tmux launchers via `_start_remote_tmux_script`; vectorize O(n²) bincount in `check_moe.py` and stop re-encoding every audio sample twice in `check_mosa.py`. Bug fix: `analysis.py` was rendering valid `0.0` latency/WER values as "-" (`if x else "-"` → `if x is not None else "-"`).

## Test plan

- [x] `poetry run pytest tests/` — 281 pass
- [x] `poetry run ruff check` — clean
- [x] `poetry run pyright tiny_audio` / `pyright scripts` — 0 errors
- [x] Pre-commit quality gate (`ta dev precommit`) — passes including mypy, bandit, interrogate, and the full test suite
- [x] `ta --help` and every subcommand (`ta dev/analysis/debug/eval/runpod/push/deploy/...`) loads
- [x] Smoke-tested helper functions for behavior parity (extract_dataset_name, parse_metrics_file, age_to_group, pace_to_label, normalize_emotion, _make_result_dir, _base_url_suffix, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)