### PR TITLE
MLX: add mlx-audio dep, RTFx benchmark, Metal pool cleanup

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1824,6 +1824,53 @@ files = [
 ]
 
 [[package]]
+name = "miniaudio"
+version = "1.70"
+description = "python bindings for the miniaudio library and its decoders (mp3, flac, ogg vorbis, wav)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and extra == \"mlx\""
+files = [
+    {file = "miniaudio-1.70-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34d0bcda68293c6efceb8ea4c2c1871979193ecd1fbc9fe408fa1a69e1fe40b4"},
+    {file = "miniaudio-1.70-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16d86fe5a9fa54b7a15d417c1bf6b1b8ddbfda0bf82acb59fff8bc01336e9bcd"},
+    {file = "miniaudio-1.70-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c3ef2023a37a1e81e5e9a65abb20934bc910336ebf23d5da3e235b1d8ee488d"},
+    {file = "miniaudio-1.70-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e68f0d0e957f716bb7ba2f20623ef032a2c0be5fb1aee4b4f5ecb6710bd2da5c"},
+    {file = "miniaudio-1.70-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e67fa7f34273e651e2f6aa36f06b31bf136e105d9d05332dd2378f89bb0a3f78"},
+    {file = "miniaudio-1.70-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:07b7a813981aeea441b35324fae20a04872d113ad9731f1fe3fad31f8ef65bab"},
+    {file = "miniaudio-1.70-cp310-cp310-win32.whl", hash = "sha256:a6db4139f66317cbad89361c82eb82be7984bb827d1c1954950160b020c2b196"},
+    {file = "miniaudio-1.70-cp310-cp310-win_amd64.whl", hash = "sha256:a71c170e3f9476f707bbb3fce1e8d8c1726be3024c3621685c0d1f29e5510f6b"},
+    {file = "miniaudio-1.70-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:06401e658d64fff8a4705f2082c093b1f1ce78bf99cbc932e2b8e48ec634cfb9"},
+    {file = "miniaudio-1.70-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:588843c600c798e37fbe25b7b9feaa891e6ca0693be89f8d51734b8be441209a"},
+    {file = "miniaudio-1.70-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8eb21a2bd770e575a0ff14b00b2120bfe9e59495f7a61c98c2e1f3942cccaad9"},
+    {file = "miniaudio-1.70-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:770ece1f3a1d6d0c8e0ce17c444b0e46b919e85389d4ef26ea8e354c0de1b840"},
+    {file = "miniaudio-1.70-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e39e40562515aea0eafbc21ff9ea7852dd42b8af4f7c65cd218569eaef93add3"},
+    {file = "miniaudio-1.70-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9c385bdcfb203276a662964ddb4b0786790c56a833cdbcab1eece767b99a3476"},
+    {file = "miniaudio-1.70-cp311-cp311-win32.whl", hash = "sha256:faec5f2d549640e1bffd19f68e6e21449bbe24a0e2eea215c8f8ba78a668d3fc"},
+    {file = "miniaudio-1.70-cp311-cp311-win_amd64.whl", hash = "sha256:1a6b58fc456d0384a39233a5889728c4d6b7fa0d105774c620e5666aad2d0bc9"},
+    {file = "miniaudio-1.70-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bfe53c6d47a13c6ae5612444731f4717a3b293990a6048d9486bf69a83e876ea"},
+    {file = "miniaudio-1.70-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c96244596485a42345b8b7094a1917857d0a4f11a25c254ec9cb8562611093d"},
+    {file = "miniaudio-1.70-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed1da7e0f903eeea3cecd8c199a39bedf27d782a9de9b81bf1db3d0840c673c"},
+    {file = "miniaudio-1.70-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec53c807dce88f457375538e7d81b87cc4366502a581f46b3ee4b50e282b7a2c"},
+    {file = "miniaudio-1.70-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fcda7999e1c170ae59019f7ddf8cfd48aafcdbc8ebd89c25f917b4910e30090e"},
+    {file = "miniaudio-1.70-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3c7116fd74ed2733a4ef6b4f23224fe968872ea89030917f1bcd5eeb7060d0f1"},
+    {file = "miniaudio-1.70-cp312-cp312-win32.whl", hash = "sha256:8adda5de804ececcd1810c9522767f87d2afb951fdd9bce0916fb586457bfc69"},
+    {file = "miniaudio-1.70-cp312-cp312-win_amd64.whl", hash = "sha256:e6c66850acafd8bacfa8b39fecc939527783ae2919336bb446c4d7d48e86e612"},
+    {file = "miniaudio-1.70-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:178bf8671c317a6dec5c2ade93394be406bd52f43ac784c5d51e3c71a23e2919"},
+    {file = "miniaudio-1.70-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e76686f21cf5d1459f64d61ac41a360db3f27e3e89b6bb61274a2ba240d36092"},
+    {file = "miniaudio-1.70-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c7b67b4dfbc2478c254fbfb6eca1d3f5f7c6062dd5f63022dfde15099fea20e"},
+    {file = "miniaudio-1.70-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad0a7ebe9ad4ae987c582f884f87945a21ac3d93131bba01d39797607a5f01cf"},
+    {file = "miniaudio-1.70-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:50cf3e80675fd34cd00c60efcb503b6254a9d4be8eb4633b401aa1d42f05c165"},
+    {file = "miniaudio-1.70-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:540e1ea433b1f2a2f63bcc4acdc8707ba89299b62db9019913367359a087b597"},
+    {file = "miniaudio-1.70-cp313-cp313-win32.whl", hash = "sha256:387213741b55daca5a2db69a89ae904f7b4bbc0440f81e66352150910ff6e416"},
+    {file = "miniaudio-1.70-cp313-cp313-win_amd64.whl", hash = "sha256:2107858d97fad7da021ffd43e109247ee10d6ca31f196f63b2ba2095df9025eb"},
+    {file = "miniaudio-1.70.tar.gz", hash = "sha256:f788504ee2b8ad3092f34b13d72875dba50597a3d25d8af3ac2f8573d31d8c31"},
+]
+
+[package.dependencies]
+cffi = ">=1.12.0"
+
+[[package]]
 name = "mlx"
 version = "0.31.2"
 description = "A framework for machine learning on Apple silicon."
@@ -1868,6 +1915,43 @@ cuda = ["mlx-cuda-12 (==0.31.2) ; platform_system == \"Linux\""]
 cuda12 = ["mlx-cuda-12 (==0.31.2) ; platform_system == \"Linux\""]
 cuda13 = ["mlx-cuda-13 (==0.31.2) ; platform_system == \"Linux\""]
 dev = ["ml_dtypes", "numpy (>=2)", "pre-commit", "psutil", "torch (>=2.9)", "typing_extensions"]
+
+[[package]]
+name = "mlx-audio"
+version = "0.0.0"
+description = "MLX-Audio is a package for inference of text-to-speech (TTS) and speech-to-speech (STS) models locally on your Mac using MLX"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and extra == \"mlx\""
+files = []
+develop = false
+
+[package.dependencies]
+huggingface_hub = ">=1.0"
+miniaudio = ">=1.61"
+mlx = ">=0.31.1"
+mlx-lm = ">=0.31.1"
+numpy = ">=1.26.4"
+scipy = ">=1.10.0"
+sounddevice = ">=0.5.3"
+tqdm = ">=4.67.1"
+transformers = ">=5.5.0"
+
+[package.extras]
+all = ["fastapi (>=0.95.0)", "mistral-common[audio]", "sentencepiece (>=0.2.0)", "setuptools (<81)", "uvicorn[standard] (>=0.22.0)", "webrtcvad (>=2.0.10)"]
+dev = ["black (>=24.2.0)", "isort (>=5.13.2)", "pre-commit (>=3.7.0)", "pytest (>=7.0.0)", "pytest-asyncio (>=1.0.0)"]
+docs = ["mkdocs-material (>=9.6)", "mkdocstrings[python] (>=0.29)"]
+server = ["fastapi (>=0.95.0)", "python-multipart (>=0.0.22)", "setuptools (<81)", "uvicorn[standard] (>=0.22.0)", "webrtcvad (>=2.0.10)"]
+sts = ["sentencepiece (>=0.2.0)", "setuptools (<81)", "webrtcvad (>=2.0.10)"]
+stt = ["sentencepiece (>=0.2.0)"]
+tts = ["mistral-common[audio]", "sentencepiece (>=0.2.0)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/Blaizzy/mlx-audio.git"
+reference = "HEAD"
+resolved_reference = "bb6533dcbca290d5e85913c70491e1b0c206970b"
 
 [[package]]
 name = "mlx-lm"
@@ -4152,6 +4236,29 @@ files = [
 ]
 
 [[package]]
+name = "sounddevice"
+version = "0.5.5"
+description = "Play and Record Sound with Python"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "sys_platform == \"darwin\" and extra == \"mlx\""
+files = [
+    {file = "sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f"},
+    {file = "sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722"},
+    {file = "sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103"},
+    {file = "sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519"},
+    {file = "sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6"},
+    {file = "sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3"},
+]
+
+[package.dependencies]
+cffi = "*"
+
+[package.extras]
+numpy = ["numpy"]
+
+[[package]]
 name = "soundfile"
 version = "0.13.1"
 description = "An audio library based on libsndfile, CFFI and NumPy"
@@ -5061,9 +5168,9 @@ propcache = ">=0.2.1"
 
 [extras]
 local = ["pyaudio"]
-mlx = ["mlx", "mlx-lm"]
+mlx = ["mlx", "mlx-audio", "mlx-lm"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "cfbb195ad06e52f750bc7de6d8bed1099354f283e9eadf0a2a361012dc4c8801"
+content-hash = "4c00c42fa381be63ba26e672f72f0f3393416e727b0aa7c34faaec9c9692c712"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ local = ["pyaudio>=0.2.14"]
 mlx = [
     "mlx>=0.20.0; sys_platform == 'darwin'",
     "mlx-lm>=0.20.0; sys_platform == 'darwin'",
+    "mlx-audio @ git+https://github.com/Blaizzy/mlx-audio.git ; sys_platform == 'darwin'",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts/bench_mlx_rtf.py
+++ b/scripts/bench_mlx_rtf.py
@@ -1,0 +1,79 @@
+"""Quick MLX RTFx benchmark.
+
+Loads MLXASRModel, warms it up, then times transcribe() on a few audio clips.
+Reports RTFx = audio_seconds / wall_clock_seconds. RTFx > 1 means faster
+than realtime.
+"""
+
+from __future__ import annotations
+
+import time
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+from tiny_audio.mlx import MLXASRModel
+
+REPO_ID = "mazesmazes/tiny-audio-embedded"
+
+
+def load_clip() -> np.ndarray:
+    """LibriSpeech sample, downsampled to 16kHz mono float32."""
+    path = librosa.ex("libri1")
+    data, sr = sf.read(path, dtype="float32")
+    if data.ndim > 1:
+        data = data.mean(axis=-1)
+    if sr != 16000:
+        data = librosa.resample(data, orig_sr=sr, target_sr=16000)
+    return data.astype(np.float32)
+
+
+def time_transcribe(model, audio: np.ndarray, *, max_new_tokens: int) -> tuple[float, str]:
+    t0 = time.perf_counter()
+    text = model.transcribe(audio, max_new_tokens=max_new_tokens)
+    return time.perf_counter() - t0, text
+
+
+def main():
+    print("Loading MLXASRModel...")
+    t0 = time.perf_counter()
+    model = MLXASRModel.from_pretrained(REPO_ID)
+    print(f"  load: {time.perf_counter() - t0:.2f}s")
+
+    print("Warming up (compiles MLX kernels)...")
+    t0 = time.perf_counter()
+    model.warmup(audio_seconds=1.0, max_new_tokens=4)
+    print(f"  warmup: {time.perf_counter() - t0:.2f}s")
+
+    full = load_clip()  # ~14.84s at 16kHz
+    full_seconds = len(full) / 16000
+
+    # Three durations: short / medium / full
+    clips = [
+        ("3.0s", full[: 16000 * 3]),
+        ("8.0s", full[: 16000 * 8]),
+        (f"{full_seconds:.2f}s", full),
+    ]
+
+    print(f"\n{'clip':>8}  {'tokens':>6}  {'wall':>7}  {'RTFx':>6}  text")
+    print("-" * 80)
+    for label, audio in clips:
+        # Run 3 times and take the median for stability
+        runs = []
+        text = ""
+        for _ in range(3):
+            wall, text = time_transcribe(model, audio, max_new_tokens=128)
+            runs.append(wall)
+        runs.sort()
+        wall = runs[1]
+        seconds = len(audio) / 16000
+        rtfx = seconds / wall
+        # Token count is approx: just split words for a quick read
+        tok = len(text.split())
+        snippet = (text[:60] + "...") if len(text) > 60 else text
+        print(f"{label:>8}  {tok:>6}  {wall:>6.2f}s  {rtfx:>5.2f}x  {snippet!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tiny_audio/mlx/model.py
+++ b/tiny_audio/mlx/model.py
@@ -279,7 +279,7 @@ class MLXASRModel:
         self,
         audio: AudioInput,
         *,
-        max_new_tokens: int = 256,
+        max_new_tokens: int = 96,
         system_prompt: str | None = None,
     ) -> str:
         """Run greedy decoding to completion and return the decoded string."""
@@ -294,7 +294,7 @@ class MLXASRModel:
         self,
         audio: AudioInput,
         *,
-        max_new_tokens: int = 256,
+        max_new_tokens: int = 96,
         system_prompt: str | None = None,
     ) -> Iterator[str]:
         """Greedy decode, yielding incremental string deltas.
@@ -328,56 +328,65 @@ class MLXASRModel:
     ) -> Iterator[int]:
         from mlx_lm.models import cache as mlx_cache
 
-        audio_np = self._prepare_audio(audio)
-        audio_embeds, num_audio = self._encode_audio(audio_np)
+        # MLX's Metal allocator is a pool that only grows to peak working set.
+        # Across many transcribe() calls with variable-length audio, the pool
+        # ratchets up until OOM. Mirror mlx-lm's reference generate.py and
+        # release the pool at the call boundary, regardless of how the
+        # generator exits (normal, EOS, exception, GeneratorExit).
+        try:
+            audio_np = self._prepare_audio(audio)
+            audio_embeds, num_audio = self._encode_audio(audio_np)
 
-        input_ids_np = build_prompt_input_ids(
-            self.tokenizer,
-            num_audio_tokens=num_audio,
-            system_prompt=system_prompt or "",
-        )
-        audio_positions = np.where(input_ids_np[0] == self.audio_token_id)[0]
-        if len(audio_positions) != num_audio:
-            raise RuntimeError(
-                f"Prompt has {len(audio_positions)} <audio> placeholders but "
-                f"projector emitted {num_audio} audio frames. The chat template "
-                f"may have stripped or duplicated placeholders."
+            input_ids_np = build_prompt_input_ids(
+                self.tokenizer,
+                num_audio_tokens=num_audio,
+                system_prompt=system_prompt or "",
             )
+            audio_positions = np.where(input_ids_np[0] == self.audio_token_id)[0]
+            if len(audio_positions) != num_audio:
+                raise RuntimeError(
+                    f"Prompt has {len(audio_positions)} <audio> placeholders but "
+                    f"projector emitted {num_audio} audio frames. The chat template "
+                    f"may have stripped or duplicated placeholders."
+                )
 
-        # The audio token id may be out-of-range for the embed table on some
-        # tokenizers (when add_special_tokens grows past the model's embedding
-        # rows). Replace those positions with id 0 before lookup; we splice the
-        # audio embeddings in immediately afterward so the value never matters.
-        safe_input_ids_np = input_ids_np.copy()
-        safe_input_ids_np[input_ids_np == self.audio_token_id] = 0
-        safe_input_ids_mx = mx.array(safe_input_ids_np)
+            # The audio token id may be out-of-range for the embed table on some
+            # tokenizers (when add_special_tokens grows past the model's embedding
+            # rows). Replace those positions with id 0 before lookup; we splice the
+            # audio embeddings in immediately afterward so the value never matters.
+            safe_input_ids_np = input_ids_np.copy()
+            safe_input_ids_np[input_ids_np == self.audio_token_id] = 0
+            safe_input_ids_mx = mx.array(safe_input_ids_np)
 
-        text_embeds = self.decoder.model.embed_tokens(safe_input_ids_mx)
-        prefill_embeds = splice_audio_embeds(text_embeds, audio_embeds, audio_positions)
+            text_embeds = self.decoder.model.embed_tokens(safe_input_ids_mx)
+            prefill_embeds = splice_audio_embeds(text_embeds, audio_embeds, audio_positions)
 
-        # Initialize KV cache and prefill via input_embeddings.
-        cache = mlx_cache.make_prompt_cache(self.decoder)
-        logits = self.decoder(safe_input_ids_mx, cache=cache, input_embeddings=prefill_embeds)
+            # Initialize KV cache and prefill via input_embeddings.
+            cache = mlx_cache.make_prompt_cache(self.decoder)
+            logits = self.decoder(safe_input_ids_mx, cache=cache, input_embeddings=prefill_embeds)
 
-        # Async-eval pipeline: keep tokens as mx.arrays (no Python int round-trip
-        # in the inner loop) and kick off step N+1 computation before syncing
-        # step N's result. The .item() sync then overlaps with the next forward
-        # pass, hiding the host<-device wait. Same pattern as mlx_lm.generate.
-        y = mx.argmax(logits[:, -1:, :], axis=-1)  # [1, 1] mx.array
-        mx.async_eval(y)
+            # Pipelined async dispatch: keep tokens as mx.arrays (no Python int
+            # round-trip in the inner loop) and kick off step N+1 computation
+            # before syncing step N's result. The .item() sync then overlaps
+            # with the next forward pass, hiding the host<-device wait. Same
+            # pattern as mlx_lm.generate.
+            y = mx.argmax(logits[:, -1:, :], axis=-1)  # [1, 1] mx.array
+            mx.async_eval(y)
 
-        for n in range(max_new_tokens):
-            if n < max_new_tokens - 1:
-                next_logits = self.decoder(y, cache=cache)
-                next_y = mx.argmax(next_logits[:, -1:, :], axis=-1)
-                mx.async_eval(next_y)
+            for n in range(max_new_tokens):
+                if n < max_new_tokens - 1:
+                    next_logits = self.decoder(y, cache=cache)
+                    next_y = mx.argmax(next_logits[:, -1:, :], axis=-1)
+                    mx.async_eval(next_y)
 
-            y_int = int(y.item())  # sync on y; overlaps with next compute above
-            yield y_int
-            if y_int in self.eos_token_ids:
-                return
-            if n < max_new_tokens - 1:
-                y = next_y
+                y_int = int(y.item())  # sync on y; overlaps with next compute above
+                yield y_int
+                if y_int in self.eos_token_ids:
+                    return
+                if n < max_new_tokens - 1:
+                    y = next_y
+        finally:
+            mx.clear_cache()
 
     # ------------------------------------------------------------- helpers
 


### PR DESCRIPTION
## Summary
- Add `mlx-audio` (git, main) to the `mlx` optional-extras. `tiny_audio/mlx/encoder.py` imports `mlx_audio.stt.models.glmasr.glmasr.WhisperEncoder`, but the latest PyPI release of `mlx-audio` (0.2.7) does not yet ship the `glmasr` submodule. Without this, `poetry install --extras mlx` resolves but inference fails with `ModuleNotFoundError`.
- Wrap `MLXASRModel._iter_token_ids` body in `try/finally` so `mx.clear_cache()` runs on every exit path (normal, EOS, exception, GeneratorExit). MLX's Metal allocator is a pool that only grows to peak working set; without this, repeated `transcribe()` calls with variable-length audio ratchet the pool toward OOM. Mirrors `mlx_lm.generate`'s pattern.
- Lower default `max_new_tokens` from 256 to 96 in `transcribe` / `transcribe_streaming`. ASR transcripts rarely exceed ~50 tokens for typical clips; the higher cap mostly bought worst-case latency on runaway generations.
- Add `scripts/bench_mlx_rtf.py`: loads a LibriSpeech sample via librosa, warms up MLX kernels, then times `transcribe()` on 3 / 8 / 14.84-second clips and reports RTFx. Median of 3 runs per clip.

## Local benchmark (M-series Mac, after warmup)

| clip | wall | RTFx |
|---|---|---|
| 3.0s | 0.07s | 42x |
| 8.0s | 0.15s | 52x |
| 14.84s | 0.28s | 54x |

## Test plan
- [ ] `poetry lock` is up to date and lockfile matches pyproject (CI / `poetry check --lock`)
- [ ] On a fresh Apple Silicon checkout: `poetry install --extras mlx` succeeds and `python -c "from mlx_audio.stt.models.glmasr.glmasr import WhisperEncoder"` imports cleanly
- [ ] `poetry run pytest tests/test_mlx_*.py -v` (excluding `slow`) passes
- [ ] `poetry run python scripts/bench_mlx_rtf.py` runs end-to-end and reports RTFx > 1
- [ ] Run `transcribe()` in a loop (e.g. 50 calls on varied lengths) and confirm Metal memory stays bounded

## Notes
- `mlx-audio` is pinned to git `HEAD` (Blaizzy/mlx-audio main). If/when a PyPI release ships the `glmasr` module we should switch back to a versioned constraint.
- The benchmark script is not wired into the `ta` CLI; it's a standalone utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)