### PR TITLE
Add CI workflow to gate PR merges on tests and checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.11"
+  POETRY_VERSION: "1.8.5"
+
+jobs:
+  checks:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: pipx install "poetry==${{ env.POETRY_VERSION }}"
+
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Cache Poetry venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction
+
+      - name: Run quality checks
+        run: poetry run ta dev check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: pipx install "poetry==${{ env.POETRY_VERSION }}"
+
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Cache Poetry venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-cache-${{ runner.os }}-v1
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction
+
+      - name: Run tests
+        run: poetry run ta dev test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on every PR and push to `main`
- `checks` job: `poetry run ta dev check` (ruff, yamllint, taplo, mypy, pyright, bandit, interrogate)
- `test` job: `poetry run ta dev test` (full pytest suite)
- Caches Poetry venv (keyed on `poetry.lock`) and HuggingFace model cache to keep re-runs fast
- Cancels in-progress runs on PR pushes; pinned Python 3.11 / Poetry 1.8.5

## Required follow-up to actually block merges
The workflow alone does not block merges. After this lands and runs once on `main`, configure branch protection:
1. **Settings → Branches → Branch protection rules** for `main`
2. Require a pull request before merging
3. Require status checks to pass before merging
4. Add `Lint & Type Check` and `Tests` as required checks

## Test plan
- [ ] First run on this PR completes successfully (cold cache — install will be slow)
- [ ] Second run on a follow-up push hits the Poetry cache and is noticeably faster
- [ ] Add the two job names as required checks under branch protection
- [ ] Open a noop PR with a deliberate lint/test failure to confirm the merge button is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)