### PR TITLE
Enable group_by_length + torch.compile for training throughput

### DIFF
--- a/configs/data/librispeech_dummy.yaml
+++ b/configs/data/librispeech_dummy.yaml
@@ -1,0 +1,20 @@
+# Tiny LibriSpeech sample (73 utterances) for local smoke tests on MPS / CPU.
+# The only split available is 'validation' — we reuse it for train and eval.
+
+datasets:
+  - path: hf-internal-testing/librispeech_asr_dummy
+    name: clean
+    audio_column: audio
+    text_column: text
+    task: transcribe
+    train_splits:
+      - validation
+    eval_splits:
+      - validation
+
+# Audio processing
+sample_rate: 16000
+
+# Processing options
+dataset_cache_dir: ${hydra:runtime.cwd}/datasets_cache
+max_eval_samples: 8

--- a/configs/experiments/mps_smoke.yaml
+++ b/configs/experiments/mps_smoke.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+# Local MPS / CPU smoke test on the 73-sample librispeech dummy dataset.
+# Validates the full train loop end-to-end without GPU-only deps.
+#
+# Usage:
+#   poetry run python scripts/train.py +experiments=mps_smoke
+
+defaults:
+  - override /data: librispeech_dummy
+
+model:
+  model_dtype: float32
+
+data:
+  num_proc: 1
+
+training:
+  max_steps: 10
+  logging_steps: 1
+  per_device_train_batch_size: 2
+  per_device_eval_batch_size: 2
+  gradient_accumulation_steps: 1
+
+  # MPS / CPU compatibility
+  bf16: false
+  tf32: false
+  torch_compile: false
+  attn_implementation: sdpa
+  dataloader_num_workers: 0
+  dataloader_persistent_workers: false
+  dataloader_prefetch_factor: null
+  dataloader_pin_memory: false
+
+  rir_augmentation:
+    enabled: false
+
+  report_to: "none"
+  save_strategy: "no"
+  eval_strategy: "no"
+  push_to_hub: false
+  output_dir: ./outputs/mps_smoke

--- a/configs/experiments/transcription.yaml
+++ b/configs/experiments/transcription.yaml
@@ -17,7 +17,7 @@ model:
 
 training:
   hub_model_id: "mazesmazes/tiny-audio"
-  group_by_length: false  # Disabled: multi-dataset configs have inconsistent duration columns
+  group_by_length: true
   learning_rate: 1e-3
   warmup_steps: 500
   lr_scheduler_type: polynomial

--- a/configs/training/production.yaml
+++ b/configs/training/production.yaml
@@ -48,7 +48,7 @@ hub_private_repo: false
 fp16: false
 bf16: true
 tf32: true
-torch_compile: false
+torch_compile: true
 model_dtype: bfloat16
 attn_implementation: flash_attention_2
 

--- a/configs/training/production.yaml
+++ b/configs/training/production.yaml
@@ -49,6 +49,10 @@ fp16: false
 bf16: true
 tf32: true
 torch_compile: true
+# group_by_length varies the batch shape per bucket, which would otherwise
+# blow past dynamo's default cache_size_limit=8 and force eager fallback.
+torch_compile_config:
+  cache_size_limit: 256
 model_dtype: bfloat16
 attn_implementation: flash_attention_2
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -61,14 +61,11 @@ class DatasetLoader:
             trust_remote_code=True,
         )
 
-        # Normalize column names for audio and text
         col_map = {
             "text": dataset_cfg.get("text_column", "text"),
             "audio": dataset_cfg.get("audio_column", "audio"),
         }
-        # duration_column is optional: only remap if explicitly configured
-        duration_source = dataset_cfg.get("duration_column")
-        if duration_source:
+        if duration_source := dataset_cfg.get("duration_column"):
             col_map["duration"] = duration_source
 
         for target, source in col_map.items():
@@ -78,24 +75,6 @@ class DatasetLoader:
                 ds = ds.rename_column(source, target)
 
         ds = ds.cast_column("audio", Audio(sampling_rate=self.sample_rate))
-
-        # Ensure every prepared split has a 'duration' column for group_by_length.
-        # If neither the source nor duration_column provides one, compute from audio length.
-        if "duration" not in ds.column_names:
-            sr = self.sample_rate
-
-            def _add_duration(batch):
-                durations = []
-                for a in batch["audio"]:
-                    arr = a["array"] if a is not None else None
-                    if arr is None:
-                        durations.append(0.0)
-                    else:
-                        n = arr.shape[0] if hasattr(arr, "shape") else len(arr)
-                        durations.append(float(n) / sr)
-                return {"duration": durations}
-
-            ds = ds.map(_add_duration, batched=True, num_proc=self.num_proc)
 
         # For multitask, keep sift_response and add task column
         if self.multitask_enabled:
@@ -137,6 +116,19 @@ class DatasetLoader:
         indices = list(range(current)) * repeats
         return ds.select(indices[:target])
 
+    def _ensure_duration(self, ds: Dataset) -> Dataset:
+        # `group_by_length` requires a `duration` column. Compute from audio
+        # length when no source field provides one. Run AFTER resampling so we
+        # don't decode samples that get trimmed.
+        if "duration" in ds.column_names:
+            return ds
+        sr = self.sample_rate
+
+        def _add_duration(batch):
+            return {"duration": [a["array"].shape[0] / sr for a in batch["audio"]]}
+
+        return ds.map(_add_duration, batched=True, num_proc=self.num_proc)
+
     def load(self) -> tuple[Dataset, Dataset]:
         train_datasets, val_datasets = [], []
 
@@ -149,10 +141,11 @@ class DatasetLoader:
                 ds = self._prepare_split(d_cfg, train_split)
                 if target_samples:
                     ds = self._resample_to_target(ds, target_samples)
-                train_datasets.append(ds)
+                train_datasets.append(self._ensure_duration(ds))
 
             for eval_split in eval_splits:
-                val_datasets.append(self._prepare_split(d_cfg, eval_split))
+                ds = self._prepare_split(d_cfg, eval_split)
+                val_datasets.append(self._ensure_duration(ds))
 
         # Concatenate and shuffle
         train_ds = (

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -489,6 +489,7 @@ def main(cfg: DictConfig) -> None:
         train_dataset=train_dataset,
         eval_dataset=val_dataset,
         data_collator=data_collator,
+        processing_class=model.tokenizer,
         callbacks=callbacks,
     )
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -66,6 +66,11 @@ class DatasetLoader:
             "text": dataset_cfg.get("text_column", "text"),
             "audio": dataset_cfg.get("audio_column", "audio"),
         }
+        # duration_column is optional: only remap if explicitly configured
+        duration_source = dataset_cfg.get("duration_column")
+        if duration_source:
+            col_map["duration"] = duration_source
+
         for target, source in col_map.items():
             if source != target and source in ds.column_names:
                 if target in ds.column_names:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -79,6 +79,24 @@ class DatasetLoader:
 
         ds = ds.cast_column("audio", Audio(sampling_rate=self.sample_rate))
 
+        # Ensure every prepared split has a 'duration' column for group_by_length.
+        # If neither the source nor duration_column provides one, compute from audio length.
+        if "duration" not in ds.column_names:
+            sr = self.sample_rate
+
+            def _add_duration(batch):
+                durations = []
+                for a in batch["audio"]:
+                    arr = a["array"] if a is not None else None
+                    if arr is None:
+                        durations.append(0.0)
+                    else:
+                        n = arr.shape[0] if hasattr(arr, "shape") else len(arr)
+                        durations.append(float(n) / sr)
+                return {"duration": durations}
+
+            ds = ds.map(_add_duration, batched=True, num_proc=self.num_proc)
+
         # For multitask, keep sift_response and add task column
         if self.multitask_enabled:
             task = dataset_cfg.get("task", "transcribe")  # Default to transcribe

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,8 +1,10 @@
-"""Tests for DatasetLoader column normalization, especially the duration column."""
+"""Tests for DatasetLoader column normalization and duration handling."""
 
 from unittest.mock import patch
 
+import numpy as np
 import pytest
+from datasets import Audio, Dataset
 from omegaconf import OmegaConf
 
 from scripts.train import DatasetLoader
@@ -22,93 +24,64 @@ def _make_cfg(datasets, sample_rate=16000, num_proc=1):
     )
 
 
+def _fake_dataset(audio_seconds: float, **extra_cols):
+    n = int(audio_seconds * 16000)
+    rows = {
+        "audio": [{"array": np.zeros(n, dtype=np.float32), "sampling_rate": 16000}],
+        **{k: [v] for k, v in extra_cols.items()},
+    }
+    return Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
+
+
+def _prepare(loader, dataset_cfg, fake):
+    with patch("scripts.train.load_dataset", return_value=fake):
+        return loader._prepare_split(OmegaConf.create(dataset_cfg), "train")
+
+
 class TestDurationColumnNormalization:
     def test_duration_column_renamed_when_specified(self):
-        """If duration_column is set, the source-named column is renamed to 'duration'."""
-        import numpy as np
-        from datasets import Audio, Dataset
-
-        rows = {
-            "audio": [{"array": np.zeros(16000, dtype=np.float32), "sampling_rate": 16000}],
-            "transcript": ["hello"],
-            "audio_len_secs": [1.0],
+        fake = _fake_dataset(audio_seconds=1.0, transcript="hello", audio_len_secs=1.0)
+        cfg = {
+            "path": "fake/dataset",
+            "audio_column": "audio",
+            "text_column": "transcript",
+            "duration_column": "audio_len_secs",
         }
-        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
-
-        cfg = _make_cfg(
-            [
-                {
-                    "path": "fake/dataset",
-                    "audio_column": "audio",
-                    "text_column": "transcript",
-                    "duration_column": "audio_len_secs",
-                    "train_splits": ["train"],
-                    "eval_splits": ["validation"],
-                }
-            ]
-        )
-        loader = DatasetLoader(cfg)
-
-        with patch("scripts.train.load_dataset", return_value=fake):
-            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+        loader = DatasetLoader(_make_cfg([cfg]))
+        ds = _prepare(loader, cfg, fake)
 
         assert "duration" in ds.column_names
         assert "audio_len_secs" not in ds.column_names
         assert ds[0]["duration"] == pytest.approx(1.0)
 
     def test_duration_already_named_correctly_kept(self):
-        import numpy as np
-        from datasets import Audio, Dataset
-
-        rows = {
-            "audio": [{"array": np.zeros(16000, dtype=np.float32), "sampling_rate": 16000}],
-            "text": ["hi"],
-            "duration": [1.0],
-        }
-        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
-        cfg = _make_cfg(
-            [
-                {
-                    "path": "fake/dataset",
-                    "audio_column": "audio",
-                    "text_column": "text",
-                    "train_splits": ["train"],
-                    "eval_splits": ["validation"],
-                }
-            ]
-        )
-        loader = DatasetLoader(cfg)
-        with patch("scripts.train.load_dataset", return_value=fake):
-            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+        fake = _fake_dataset(audio_seconds=1.0, text="hi", duration=1.0)
+        cfg = {"path": "fake/dataset", "audio_column": "audio", "text_column": "text"}
+        loader = DatasetLoader(_make_cfg([cfg]))
+        ds = _prepare(loader, cfg, fake)
 
         assert "duration" in ds.column_names
         assert ds[0]["duration"] == pytest.approx(1.0)
 
-    def test_duration_computed_from_audio_when_missing(self):
-        """If neither duration nor duration_column is present, compute from audio array length."""
-        import numpy as np
-        from datasets import Audio, Dataset
 
-        # Sample is exactly 2.5 seconds at 16kHz
-        rows = {
-            "audio": [{"array": np.zeros(40000, dtype=np.float32), "sampling_rate": 16000}],
-            "text": ["hello"],
-        }
-        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
-        cfg = _make_cfg(
-            [
-                {
-                    "path": "fake/dataset",
-                    "audio_column": "audio",
-                    "text_column": "text",
-                    "train_splits": ["train"],
-                    "eval_splits": ["validation"],
-                }
-            ]
-        )
-        loader = DatasetLoader(cfg)
-        with patch("scripts.train.load_dataset", return_value=fake):
-            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+class TestEnsureDuration:
+    def test_computes_from_audio_when_missing(self):
+        fake = _fake_dataset(audio_seconds=2.5, text="hello")
+        cfg = {"path": "fake/dataset", "audio_column": "audio", "text_column": "text"}
+        loader = DatasetLoader(_make_cfg([cfg]))
+        ds = _prepare(loader, cfg, fake)
+        assert "duration" not in ds.column_names
+
+        ds = loader._ensure_duration(ds)
 
         assert "duration" in ds.column_names
         assert ds[0]["duration"] == pytest.approx(2.5, abs=0.01)
+
+    def test_noop_when_duration_present(self):
+        fake = _fake_dataset(audio_seconds=2.5, text="hi", duration=999.0)
+        cfg = {"path": "fake/dataset", "audio_column": "audio", "text_column": "text"}
+        loader = DatasetLoader(_make_cfg([cfg]))
+        ds = _prepare(loader, cfg, fake)
+        ds = loader._ensure_duration(ds)
+
+        assert ds[0]["duration"] == pytest.approx(999.0)

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,6 +1,6 @@
 """Tests for DatasetLoader column normalization, especially the duration column."""
 
-from unittest.mock import MagicMock, patch  # noqa: F401
+from unittest.mock import patch
 
 import pytest
 from omegaconf import OmegaConf

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -83,3 +83,32 @@ class TestDurationColumnNormalization:
 
         assert "duration" in ds.column_names
         assert ds[0]["duration"] == pytest.approx(1.0)
+
+    def test_duration_computed_from_audio_when_missing(self):
+        """If neither duration nor duration_column is present, compute from audio array length."""
+        import numpy as np
+        from datasets import Audio, Dataset
+
+        # Sample is exactly 2.5 seconds at 16kHz
+        rows = {
+            "audio": [{"array": np.zeros(40000, dtype=np.float32), "sampling_rate": 16000}],
+            "text": ["hello"],
+        }
+        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
+        cfg = _make_cfg(
+            [
+                {
+                    "path": "fake/dataset",
+                    "audio_column": "audio",
+                    "text_column": "text",
+                    "train_splits": ["train"],
+                    "eval_splits": ["validation"],
+                }
+            ]
+        )
+        loader = DatasetLoader(cfg)
+        with patch("scripts.train.load_dataset", return_value=fake):
+            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+
+        assert "duration" in ds.column_names
+        assert ds[0]["duration"] == pytest.approx(2.5, abs=0.01)

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,0 +1,85 @@
+"""Tests for DatasetLoader column normalization, especially the duration column."""
+
+from unittest.mock import MagicMock, patch  # noqa: F401
+
+import pytest
+from omegaconf import OmegaConf
+
+from scripts.train import DatasetLoader
+
+
+def _make_cfg(datasets, sample_rate=16000, num_proc=1):
+    return OmegaConf.create(
+        {
+            "data": {
+                "datasets": datasets,
+                "sample_rate": sample_rate,
+                "dataset_cache_dir": None,
+                "num_proc": num_proc,
+            },
+            "training": {"seed": 42},
+        }
+    )
+
+
+class TestDurationColumnNormalization:
+    def test_duration_column_renamed_when_specified(self):
+        """If duration_column is set, the source-named column is renamed to 'duration'."""
+        import numpy as np
+        from datasets import Audio, Dataset
+
+        rows = {
+            "audio": [{"array": np.zeros(16000, dtype=np.float32), "sampling_rate": 16000}],
+            "transcript": ["hello"],
+            "audio_len_secs": [1.0],
+        }
+        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
+
+        cfg = _make_cfg(
+            [
+                {
+                    "path": "fake/dataset",
+                    "audio_column": "audio",
+                    "text_column": "transcript",
+                    "duration_column": "audio_len_secs",
+                    "train_splits": ["train"],
+                    "eval_splits": ["validation"],
+                }
+            ]
+        )
+        loader = DatasetLoader(cfg)
+
+        with patch("scripts.train.load_dataset", return_value=fake):
+            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+
+        assert "duration" in ds.column_names
+        assert "audio_len_secs" not in ds.column_names
+        assert ds[0]["duration"] == pytest.approx(1.0)
+
+    def test_duration_already_named_correctly_kept(self):
+        import numpy as np
+        from datasets import Audio, Dataset
+
+        rows = {
+            "audio": [{"array": np.zeros(16000, dtype=np.float32), "sampling_rate": 16000}],
+            "text": ["hi"],
+            "duration": [1.0],
+        }
+        fake = Dataset.from_dict(rows).cast_column("audio", Audio(sampling_rate=16000))
+        cfg = _make_cfg(
+            [
+                {
+                    "path": "fake/dataset",
+                    "audio_column": "audio",
+                    "text_column": "text",
+                    "train_splits": ["train"],
+                    "eval_splits": ["validation"],
+                }
+            ]
+        )
+        loader = DatasetLoader(cfg)
+        with patch("scripts.train.load_dataset", return_value=fake):
+            ds = loader._prepare_split(cfg.data.datasets[0], "train")
+
+        assert "duration" in ds.column_names
+        assert ds[0]["duration"] == pytest.approx(1.0)

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -422,14 +422,12 @@ class ASRModel(PreTrainedModel, GenerationMixin):
     def _encode_audio(
         self,
         audio_features: torch.Tensor,
-        audio_attention_mask: torch.Tensor,
         expected_token_counts: torch.Tensor,
     ) -> torch.Tensor:
         """Encode audio features and return flattened embeddings matching expected_token_counts.
 
         Args:
             audio_features: Mel spectrogram features (batch, n_mels, mel_len)
-            audio_attention_mask: Mask indicating real vs padded mel frames (batch, mel_len)
             expected_token_counts: Per-sample audio token counts as int64 tensor (batch,).
 
         Returns:
@@ -475,9 +473,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
                     device=input_ids.device, dtype=torch.long
                 )
 
-            audio_embeds = self._encode_audio(
-                input_features, audio_attention_mask, audio_token_counts
-            )
+            audio_embeds = self._encode_audio(input_features, audio_token_counts)
 
             audio_token_mask = is_audio_token.unsqueeze(-1)
             inputs_embeds = inputs_embeds.masked_scatter(
@@ -561,7 +557,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             device=input_features.device,
             dtype=torch.long,
         )
-        audio_embeds = self._encode_audio(input_features, audio_attention_mask, token_counts)
+        audio_embeds = self._encode_audio(input_features, token_counts)
 
         # If input_ids not provided, build prompt with correct number of audio tokens
         if input_ids is None:
@@ -651,7 +647,7 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             device=input_features.device,
             dtype=torch.long,
         )
-        audio_embeds = self._encode_audio(input_features, audio_attention_mask, token_counts)
+        audio_embeds = self._encode_audio(input_features, token_counts)
 
         # Build prompt with correct number of audio tokens
         num_audio_tokens = self._get_num_audio_tokens(audio_attention_mask)


### PR DESCRIPTION
## Summary

Compute-bound training optimizations that didn't make PR #46. Three independent changes targeting throughput on the multi-dataset transcription recipe:

- **Re-enable \`group_by_length\` for multi-dataset training.** Was disabled because not every source dataset shipped a \`duration\` column. Adds (a) an optional \`duration_column\` config knob to rename non-standard duration fields and (b) a fallback that computes duration from the audio array when neither is present. Length-bucketed batching collapses padding waste in the encoder; expected win 15–30% on \`multiasr\` depending on length variance.
- **Enable \`torch.compile\`** on the production config, with \`torch_compile_config.cache_size_limit=256\` to absorb the per-bucket shape variation \`group_by_length\` produces (default is 8 — would have thrashed and fallen back to eager).
- **Drop unused \`audio_attention_mask\` parameter** from \`_encode_audio\` and its three call sites. Cleanup follow-up to PR #46's vectorization.

\`_ensure_duration\` runs after \`_resample_to_target\` so we don't decode audio for samples that get trimmed away.

## Test plan

- [x] \`pytest tests/test_dataset_loader.py tests/test_data_collator.py tests/test_projectors.py tests/test_encode_audio_gather.py tests/test_asr_processing.py\` — 57 passed
- [ ] MPS smoke run with RIR/compile/bf16 disabled (local validation)
- [ ] Full RunPod 200-step throughput benchmark vs main baseline
- [ ] Verify training loss curve doesn't shift materially with \`group_by_length=true\`
- [ ] Verify \`torch.compile=true\` doesn't regress (cache_size_limit bumped to 256; watch for graph-break warnings on first few steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)