### PR TITLE
Expand embedded projector hidden to 2x llm_dim

### DIFF
--- a/configs/experiments/embedded.yaml
+++ b/configs/experiments/embedded.yaml
@@ -11,7 +11,7 @@ defaults:
 model:
   projector_type: mlp
   projector_pool_stride: 4
-  projector_hidden_dim: 1024
+  projector_hidden_dim: 2048
   audio_model_id: zai-org/GLM-ASR-Nano-2512
   # Qwen3-0.6B ships with a chat_template, which DataCollatorForChatML requires.
   text_model_id: Qwen/Qwen3-0.6B
@@ -33,7 +33,7 @@ training:
   gradient_accumulation_steps: 2
   num_train_epochs: 2
   save_steps: 1000
-  eval_steps: 5000
+  eval_steps: 1000
 
   # Keep the Blackwell fed; audio decode + mel extraction is the bottleneck at this batch size.
   dataloader_num_workers: 16

--- a/scripts/deploy/runpod.py
+++ b/scripts/deploy/runpod.py
@@ -126,6 +126,7 @@ RSYNC_EXCLUDES = [
     "__pycache__",
     "*.pyc",
     ".git",
+    ".worktrees",
     ".venv",
     "venv",
     "env",


### PR DESCRIPTION
## Summary
- `configs/experiments/embedded.yaml`: `projector_hidden_dim` 1024 → 2048 to match GLM-ASR-Nano's native projector shape (hidden = 2 × text_hidden_size); also tighten `eval_steps` 5000 → 1000.
- `scripts/deploy/runpod.py`: add `.worktrees` to `RSYNC_EXCLUDES` so worktree directories aren't synced to RunPod.

## Why
GLM-ASR-Nano-2512's own multimodal projector (in `transformers.models.glmasr`) is a 2-layer MLP with `linear_1: enc_intermediate → 2 × llm_hidden`, `linear_2: 2 × llm_hidden → llm_hidden`. The encoder features were learned alongside that expansion, so a `hidden_dim = llm_dim` projector is sub-optimal for this encoder. With Qwen3-0.6B (`hidden_size=1024`), 2× expansion → 2048.

## Test plan
- [ ] `poetry run pytest tests/test_scripts_deploy.py -v` (deploy tests pass with new exclude)
- [ ] Kick off `poetry run python scripts/train.py +experiments=embedded` and confirm projector instantiates with the new hidden dim
- [ ] Verify training loss curve looks sane vs. previous embedded run

🤖 Generated with [Claude Code](https://claude.com/claude-code)