### PR TITLE
Bump GigaSpeech share in multiasr to ~10%

### DIFF
--- a/configs/data/multiasr.yaml
+++ b/configs/data/multiasr.yaml
@@ -10,14 +10,14 @@
 # ┌──────────────────┬───────────┬─────────┐
 # │ Dataset          │ Samples   │ Percent │
 # ├──────────────────┼───────────┼─────────┤
-# │ loquacious med   │ 1,090,000 │   50.0% │
-# │ ami-ihm          │   305,000 │   14.0% │
-# │ ami-sdm          │   175,000 │    8.0% │
-# │ spgispeech L     │   260,000 │   12.0% │
-# │ switchboard      │   260,000 │   12.0% │
-# │ gigaspeech m     │    87,000 │    4.0% │
+# │ loquacious med   │ 1,090,000 │   46.9% │
+# │ ami-ihm          │   305,000 │   13.1% │
+# │ ami-sdm          │   175,000 │    7.5% │
+# │ spgispeech L     │   260,000 │   11.2% │
+# │ switchboard      │   260,000 │   11.2% │
+# │ gigaspeech m     │   232,000 │   10.0% │
 # └──────────────────┴───────────┴─────────┘
-# Total: ~2,177,000 samples
+# Total: ~2,322,000 samples
 #
 # Loquacious is uncapped (full medium ~1.09M); other streams scaled to hit
 # the target proportions. AMI IHM/SDM and Switchboard upsample (~2-3x repeats)
@@ -84,7 +84,7 @@ datasets:
     task: transcribe
     train_splits: [train]
     eval_splits: [validation]
-    target_samples: 87000
+    target_samples: 232000
 
 # Audio processing
 sample_rate: 16000


### PR DESCRIPTION
## Summary
- `configs/data/multiasr.yaml`: raise GigaSpeech-m `target_samples` from 87,000 → 232,000 so it sits at ~10% of the multiasr mix; all other dataset counts unchanged.
- Updated the comment table to reflect the new shares.

## Why
GigaSpeech is the only direct in-domain training data for the GigaSpeech eval (not present in Loquacious), and 4% was under-weighting it relative to its eval importance. Holding all other counts constant and rebalancing only GigaSpeech keeps the rest of the mix's behavior unchanged.

## New mix
| Dataset | Samples | Percent |
| --- | ---: | ---: |
| Loquacious medium | 1,090,000 | 46.9% |
| AMI-IHM | 305,000 | 13.1% |
| AMI-SDM | 175,000 | 7.5% |
| SPGISpeech L | 260,000 | 11.2% |
| Switchboard | 260,000 | 11.2% |
| **GigaSpeech m** | **232,000** | **10.0%** |
| **Total** | **~2,322,000** | |

GigaSpeech-m has ~360k samples (~1000hr at ~10s avg), so 232k stays well under cap — no upsampling needed.

## Test plan
- [ ] Smoke-train `+experiments=transcription` and confirm the new GigaSpeech sample count is hit
- [ ] Confirm GigaSpeech eval WER moves vs. previous mix on a short run

🤖 Generated with [Claude Code](https://claude.com/claude-code)