### PR TITLE
Remove GigaSpeech; skip duration prep when group_by_length is off

### DIFF
--- a/configs/data/multiasr.yaml
+++ b/configs/data/multiasr.yaml
@@ -10,14 +10,13 @@
 # ┌──────────────────┬───────────┬─────────┐
 # │ Dataset          │ Samples   │ Percent │
 # ├──────────────────┼───────────┼─────────┤
-# │ loquacious med   │ 1,090,000 │   46.9% │
-# │ ami-ihm          │   305,000 │   13.1% │
-# │ ami-sdm          │   175,000 │    7.5% │
-# │ spgispeech L     │   260,000 │   11.2% │
-# │ switchboard      │   260,000 │   11.2% │
-# │ gigaspeech xl    │   232,000 │   10.0% │
+# │ loquacious med   │ 1,090,000 │   52.2% │
+# │ ami-ihm          │   305,000 │   14.6% │
+# │ ami-sdm          │   175,000 │    8.4% │
+# │ spgispeech L     │   260,000 │   12.4% │
+# │ switchboard      │   260,000 │   12.4% │
 # └──────────────────┴───────────┴─────────┘
-# Total: ~2,322,000 samples
+# Total: ~2,090,000 samples
 #
 # Loquacious is uncapped (full medium ~1.09M); other streams scaled to hit
 # the target proportions. AMI IHM/SDM and Switchboard upsample (~2-3x repeats)
@@ -74,20 +73,6 @@ datasets:
     train_splits: [train]
     eval_splits: [validation]
     target_samples: 260000
-
-  # GigaSpeech XL (empty-audio-removed) - YouTube/podcast/audiobook mix.
-  # Direct training data for the GigaSpeech eval (not in Loquacious).
-  # fixie-ai/gigaspeech only ships {dev, xl, xl-empty-audio-removed} — no
-  # smaller subsets — so we stream from the full XL pool and cap with
-  # target_samples for the desired ~10% mix share.
-  - path: fixie-ai/gigaspeech
-    name: xl-empty-audio-removed
-    audio_column: audio
-    text_column: text
-    task: transcribe
-    train_splits: [train]
-    eval_splits: [validation]
-    target_samples: 232000
 
 # Audio processing
 sample_rate: 16000

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -15,6 +15,7 @@ import wandb
 from datasets import (
     Audio,
     Dataset,
+    Value,
     concatenate_datasets,
     load_dataset,
 )
@@ -45,6 +46,10 @@ class DatasetLoader:
         self.cache_dir = self.config.dataset_cache_dir
         self.seed = config.training.get("seed", 42)
         self.num_proc = self.config.get("num_proc", 16)
+        # `duration` is only consumed by Trainer's group_by_length sampler; skip
+        # any duration prep when group_by_length is off. Avoids a slow column
+        # cast (and potentially a full-decode map) on every train run.
+        self.needs_duration = bool(config.training.get("group_by_length", False))
         self.multitask_enabled = multitask_enabled
 
     def _prepare_split(self, dataset_cfg: DictConfig, split: str):
@@ -81,13 +86,12 @@ class DatasetLoader:
             task = dataset_cfg.get("task", "transcribe")  # Default to transcribe
             # Add task column to identify ASR vs SIFT samples
             ds = ds.add_column("task", [task] * len(ds))
-            keep_cols = {"audio", "text", "duration", "sift_response", "task"}
-            extra_cols = [c for c in (ds.column_names or []) if c not in keep_cols]
+            keep_cols = {"audio", "text", "sift_response", "task"}
         else:
-            # Remove extra columns, keep only audio, text, and duration (for group_by_length)
-            extra_cols = [
-                c for c in (ds.column_names or []) if c not in {"audio", "text", "duration"}
-            ]
+            keep_cols = {"audio", "text"}
+        if self.needs_duration:
+            keep_cols = keep_cols | {"duration"}
+        extra_cols = [c for c in (ds.column_names or []) if c not in keep_cols]
 
         if extra_cols:
             ds = ds.remove_columns(extra_cols)
@@ -119,15 +123,20 @@ class DatasetLoader:
     def _ensure_duration(self, ds: Dataset) -> Dataset:
         # `group_by_length` requires a `duration` column. Compute from audio
         # length when no source field provides one. Run AFTER resampling so we
-        # don't decode samples that get trimmed.
-        if "duration" in ds.column_names:
-            return ds
-        sr = self.sample_rate
+        # don't decode samples that get trimmed. Cast to float32 only when the
+        # source ships a different dtype (sources mix float32/float64/null and
+        # concatenate_datasets rejects the mismatch); skipping a no-op cast
+        # avoids a multi-minute column rewrite on large streams.
+        if "duration" not in ds.column_names:
+            sr = self.sample_rate
 
-        def _add_duration(batch):
-            return {"duration": [a["array"].shape[0] / sr for a in batch["audio"]]}
+            def _add_duration(batch):
+                return {"duration": [a["array"].shape[0] / sr for a in batch["audio"]]}
 
-        return ds.map(_add_duration, batched=True, num_proc=self.num_proc)
+            ds = ds.map(_add_duration, batched=True, num_proc=self.num_proc)
+        if ds.features["duration"].dtype != "float32":
+            ds = ds.cast_column("duration", Value("float32"))
+        return ds
 
     def load(self) -> tuple[Dataset, Dataset]:
         train_datasets, val_datasets = [], []
@@ -141,11 +150,15 @@ class DatasetLoader:
                 ds = self._prepare_split(d_cfg, train_split)
                 if target_samples:
                     ds = self._resample_to_target(ds, target_samples)
-                train_datasets.append(self._ensure_duration(ds))
+                if self.needs_duration:
+                    ds = self._ensure_duration(ds)
+                train_datasets.append(ds)
 
             for eval_split in eval_splits:
                 ds = self._prepare_split(d_cfg, eval_split)
-                val_datasets.append(self._ensure_duration(ds))
+                if self.needs_duration:
+                    ds = self._ensure_duration(ds)
+                val_datasets.append(ds)
 
         # Concatenate and shuffle
         train_ds = (

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -10,7 +10,7 @@ from omegaconf import OmegaConf
 from scripts.train import DatasetLoader
 
 
-def _make_cfg(datasets, sample_rate=16000, num_proc=1):
+def _make_cfg(datasets, sample_rate=16000, num_proc=1, group_by_length=True):
     return OmegaConf.create(
         {
             "data": {
@@ -19,7 +19,7 @@ def _make_cfg(datasets, sample_rate=16000, num_proc=1):
                 "dataset_cache_dir": None,
                 "num_proc": num_proc,
             },
-            "training": {"seed": 42},
+            "training": {"seed": 42, "group_by_length": group_by_length},
         }
     )
 
@@ -85,3 +85,13 @@ class TestEnsureDuration:
         ds = loader._ensure_duration(ds)
 
         assert ds[0]["duration"] == pytest.approx(999.0)
+
+
+class TestGroupByLengthDisabled:
+    def test_duration_dropped_when_group_by_length_off(self):
+        fake = _fake_dataset(audio_seconds=1.0, text="hi", duration=1.0)
+        cfg = {"path": "fake/dataset", "audio_column": "audio", "text_column": "text"}
+        loader = DatasetLoader(_make_cfg([cfg], group_by_length=False))
+        ds = _prepare(loader, cfg, fake)
+
+        assert "duration" not in ds.column_names


### PR DESCRIPTION
## Summary
- `configs/data/multiasr.yaml`: drop GigaSpeech from the mix; remaining 5 sources rebalance to ~52/15/8/12/12 (Loquacious / AMI-IHM / AMI-SDM / SPGI / Switchboard).
- `scripts/train.py`: skip `_ensure_duration` entirely when `training.group_by_length` is off, and only cast `duration` to `float32` when the source dtype actually differs.
- `tests/test_dataset_loader.py`: cover the new `group_by_length=False` path.

## Why
Two bugs surfaced when running `+experiments=embedded` (which has `group_by_length: false`):

1. **Concat failure**: sources ship `duration` as `float32`, `float64`, or `null`, while the locally-computed duration came out as `float64`, so `concatenate_datasets` rejected the mismatch.
2. **Slow path**: the previous fix (always cast every source to `float32`) was a multi-minute (sometimes hour-long) column rewrite on large streams, even when `group_by_length` was off and the duration column was never read by training.

The new logic:
- `needs_duration = bool(training.group_by_length)` — when False, `_ensure_duration` is skipped and `duration` is dropped from `keep_cols`, so `concatenate_datasets` never sees the mismatched dtypes.
- When `needs_duration=True`, only cast when dtype != `float32` (skips no-op rewrites).

For `embedded.yaml` (`group_by_length: false`) this eliminates the duration-handling work entirely. For `transcription.yaml` (`group_by_length: true`) it keeps the dtype guarantee but avoids redundant casts.

## New mix (multiasr)
| Dataset | Samples | Percent |
| --- | ---: | ---: |
| Loquacious medium | 1,090,000 | 52.2% |
| AMI-IHM | 305,000 | 14.6% |
| AMI-SDM | 175,000 | 8.4% |
| SPGISpeech | 260,000 | 12.4% |
| Switchboard | 260,000 | 12.4% |
| **Total** | **~2,090,000** | |

## Test plan
- [x] `poetry run pytest tests/test_dataset_loader.py -v` (5 passed)
- [ ] Run `+experiments=embedded` end-to-end on RunPod and confirm dataset load completes without the dtype mismatch and without the slow cast pass
- [ ] Run `+experiments=transcription` smoke pass to confirm `group_by_length=True` path still computes/keeps `duration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)