### PR TITLE
Support full decoder fine-tuning with decoupled LR/weight decay

### DIFF
--- a/configs/experiments/embedded.yaml
+++ b/configs/experiments/embedded.yaml
@@ -19,19 +19,27 @@ model:
 training:
   hub_model_id: "mazesmazes/tiny-audio-embedded"
   group_by_length: false  # Disabled: multi-dataset configs have inconsistent duration columns
+  # Full decoder fine-tuning (projector + Qwen3-0.6B). Saved checkpoints contain the full LM.
+  freeze_language_model: false
   # Tuned for RTX PRO 6000 Blackwell Server Edition (96 GB).
-  # LR/warmup mirror transcription.yaml for comparability.
+  # Projector LR mirrors transcription.yaml; the LM gets a much lower LR
+  # (typical full-decoder fine-tuning range) to avoid catastrophic forgetting.
   learning_rate: 1e-3
-  warmup_steps: 500
-  lr_scheduler_type: polynomial
-  lr_scheduler_kwargs:
-    power: 0.5
+  decoder_learning_rate: 1e-5
+  # Standard AdamW weight decay for full LM fine-tuning. Decoupled from the
+  # projector's `weight_decay` (0.0) below.
+  decoder_weight_decay: 0.01
+  # Wider warmup gives the randomly-initialized projector time to settle before
+  # the LM's much smaller LR starts to bite — important now that the LM is
+  # trainable and the projector dominates early gradients.
+  warmup_steps: 2000
+  lr_scheduler_type: cosine
   seed: 42
   auto_find_batch_size: false
   per_device_train_batch_size: 32
   per_device_eval_batch_size: 32
   gradient_accumulation_steps: 2
-  num_train_epochs: 3
+  num_train_epochs: 2
   save_steps: 1000
   eval_steps: 1000
 

--- a/configs/experiments/mps_smoke.yaml
+++ b/configs/experiments/mps_smoke.yaml
@@ -1,6 +1,8 @@
 # @package _global_
 # Local MPS / CPU smoke test on the 73-sample librispeech dummy dataset.
-# Validates the full train loop end-to-end without GPU-only deps.
+# Validates the full train loop end-to-end without GPU-only deps, including
+# the full-decoder fine-tuning path with a separate LR for the LM (the same
+# flags used by configs/experiments/embedded.yaml).
 #
 # Usage:
 #   poetry run python scripts/train.py +experiments=mps_smoke
@@ -17,9 +19,23 @@ data:
 training:
   max_steps: 10
   logging_steps: 1
-  per_device_train_batch_size: 2
-  per_device_eval_batch_size: 2
+  # Batch size 1 — full Qwen3-0.6B fine-tuning in float32 adds ~7 GB of
+  # gradient + AdamW state on top of the frozen-LM smoke test footprint.
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 1
   gradient_accumulation_steps: 1
+  # Trade compute for memory so this fits comfortably in unified memory.
+  gradient_checkpointing: true
+
+  # Exercise the decoder fine-tuning path. The two LRs must differ so the
+  # parameter-group split in ASRTrainer.create_optimizer is actually taken.
+  freeze_language_model: false
+  learning_rate: 1e-3
+  decoder_learning_rate: 1e-5
+  decoder_weight_decay: 0.01
+  # Default `adamw_torch_fused` is CUDA-only; use the plain implementation
+  # so the optimizer constructs on MPS / CPU.
+  optim: adamw_torch
 
   # MPS / CPU compatibility
   bf16: false
@@ -32,6 +48,8 @@ training:
   dataloader_pin_memory: false
 
   rir_augmentation:
+    enabled: false
+  noise_augmentation:
     enabled: false
 
   report_to: "none"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -304,6 +304,67 @@ class MultiTaskDataCollator(DataCollator):
 class ASRTrainer(Trainer):
     """Trainer subclass for ASR models."""
 
+    def __init__(
+        self,
+        *args,
+        decoder_learning_rate: float | None = None,
+        decoder_weight_decay: float | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.decoder_learning_rate = decoder_learning_rate
+        self.decoder_weight_decay = decoder_weight_decay
+
+    def create_optimizer(self):
+        """Optimizer with separate LR / weight decay for the language model.
+
+        Mirrors HF Trainer.create_optimizer's decay/no-decay split, but adds a
+        second axis: parameters under `language_model.` get `decoder_learning_rate`
+        and `decoder_weight_decay` (when set), while the projector keeps
+        `args.learning_rate` and `args.weight_decay`.
+        """
+        decoder_overrides = (
+            self.decoder_learning_rate is not None or self.decoder_weight_decay is not None
+        )
+        if self.optimizer is not None or not decoder_overrides:
+            return super().create_optimizer()
+
+        from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
+        from transformers.trainer_pt_utils import get_parameter_names
+
+        opt_model = self.model
+        decay_parameters = set(get_parameter_names(opt_model, ALL_LAYERNORM_LAYERS))
+        decay_parameters = {n for n in decay_parameters if "bias" not in n}
+
+        groups: dict[tuple[bool, bool], list] = {
+            (True, True): [],  # decoder, decay
+            (True, False): [],  # decoder, no decay
+            (False, True): [],  # other, decay
+            (False, False): [],  # other, no decay
+        }
+        for name, param in opt_model.named_parameters():
+            if not param.requires_grad:
+                continue
+            is_decoder = name.startswith("language_model.")
+            decay = name in decay_parameters
+            groups[(is_decoder, decay)].append(param)
+
+        base_wd = self.args.weight_decay
+        base_lr = self.args.learning_rate
+        dec_lr = self.decoder_learning_rate if self.decoder_learning_rate is not None else base_lr
+        dec_wd = self.decoder_weight_decay if self.decoder_weight_decay is not None else base_wd
+        optimizer_grouped_parameters = [
+            {"params": groups[(False, True)], "weight_decay": base_wd, "lr": base_lr},
+            {"params": groups[(False, False)], "weight_decay": 0.0, "lr": base_lr},
+            {"params": groups[(True, True)], "weight_decay": dec_wd, "lr": dec_lr},
+            {"params": groups[(True, False)], "weight_decay": 0.0, "lr": dec_lr},
+        ]
+        optimizer_grouped_parameters = [g for g in optimizer_grouped_parameters if g["params"]]
+
+        optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args, opt_model)
+        self.optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
+        return self.optimizer
+
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         """Compute loss with proper label shifting for causal LM.
 
@@ -370,6 +431,7 @@ TRAINING_MODEL_PARAMS = [
     "lora_dropout",
     "lora_target_modules",
     "freeze_projector",
+    "freeze_language_model",
 ]
 
 
@@ -491,6 +553,8 @@ def main(cfg: DictConfig) -> None:
 
     training_config = OmegaConf.to_container(cfg.training, resolve=True)
     assert isinstance(training_config, dict)
+    decoder_learning_rate = training_config.pop("decoder_learning_rate", None)
+    decoder_weight_decay = training_config.pop("decoder_weight_decay", None)
     if compile_config := training_config.pop("torch_compile_config", None):
         torch._dynamo.config.cache_size_limit = compile_config.get("cache_size_limit", 64)
         torch._dynamo.config.capture_scalar_outputs = compile_config.get(
@@ -506,6 +570,8 @@ def main(cfg: DictConfig) -> None:
         data_collator=data_collator,
         processing_class=model.tokenizer,
         callbacks=callbacks,
+        decoder_learning_rate=decoder_learning_rate,
+        decoder_weight_decay=decoder_weight_decay,
     )
 
     trainer.train(resume_from_checkpoint=cfg.training.get("resume_from_checkpoint"))

--- a/tiny_audio/asr_config.py
+++ b/tiny_audio/asr_config.py
@@ -66,6 +66,7 @@ class ASRConfig(transformers.PretrainedConfig):
         lora_dropout: float = 0.0,
         lora_target_modules: Optional[list] = None,  # Default: all linear layers
         freeze_projector: bool = False,  # True for Stage 2 (LoRA-only training)
+        freeze_language_model: bool = True,  # False = full decoder fine-tuning
         do_sample: bool = False,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
@@ -152,6 +153,7 @@ class ASRConfig(transformers.PretrainedConfig):
             "down_proj",
         ]
         self.freeze_projector = freeze_projector
+        self.freeze_language_model = freeze_language_model
 
         explicit_generation_args = {
             "num_beams": num_beams,

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -265,8 +265,9 @@ class ASRModel(PreTrainedModel, GenerationMixin):
 
         decoder = AutoModelForCausalLM.from_pretrained(config.text_model_id, **decoder_kwargs)
         decoder.config.use_cache = getattr(config, "use_cache", True)
-        decoder.requires_grad_(False)
-        decoder.eval()
+        if getattr(config, "freeze_language_model", True):
+            decoder.requires_grad_(False)
+            decoder.train(False)
         return decoder
 
     def _create_projector(self, config: ASRConfig, dtype: torch.dtype) -> nn.Module:
@@ -395,8 +396,13 @@ class ASRModel(PreTrainedModel, GenerationMixin):
         )
 
     def state_dict(self, *args, **kwargs) -> dict[str, torch.Tensor]:
-        """Only save trainable projector weights."""
-        return {f"projector.{k}": v for k, v in self.projector.state_dict().items()}
+        """Save trainable weights: projector, plus the language model when fine-tuned."""
+        sd = {f"projector.{k}": v for k, v in self.projector.state_dict().items()}
+        if not getattr(self.config, "freeze_language_model", True):
+            sd.update(
+                {f"language_model.{k}": v for k, v in self.language_model.state_dict().items()}
+            )
+        return sd
 
     def _compute_encoder_output_lengths(
         self,


### PR DESCRIPTION
## Summary

- Adds `freeze_language_model` config flag (default `True` for backward compat). When `False`, the decoder trains end-to-end and `state_dict()` saves the language model weights alongside the projector.
- Extends `ASRTrainer` with optional `decoder_learning_rate` / `decoder_weight_decay`. When either is set, `create_optimizer` builds four parameter groups (projector × decoder × decay × no-decay) so the LM can take its own LR and weight decay; otherwise it falls through to HF's default optimizer.
- Switches `configs/experiments/embedded.yaml` to full decoder fine-tuning: projector LR 1e-3, decoder LR 1e-5, decoder weight decay 0.01, cosine schedule, 2000 warmup steps, 2 epochs.
- Updates `configs/experiments/mps_smoke.yaml` to exercise the same path locally (batch size 1, gradient checkpointing, `adamw_torch` since the production fused optimizer is CUDA-only, and noise/RIR augmentation disabled to avoid MUSAN/OpenSLR-28 corpus dependencies).

## Test plan

- [ ] `poetry run python scripts/train.py +experiments=mps_smoke` completes 10 steps locally on MPS / CPU
- [ ] Trainable param count is ~600M (projector + Qwen3-0.6B), not ~12M (projector only)
- [ ] Loss decreases over the 10 logged smoke steps
- [ ] On the Blackwell box: `poetry run python scripts/train.py +experiments=embedded` constructs the optimizer with four parameter groups (LRs 1e-3 / 1e-5, weight decays 0.0 / 0.01)
- [ ] Saved checkpoint contains `language_model.*` keys (verifies the `state_dict` extension)
- [ ] Existing projector-only configs still work (default `freeze_language_model: True` keeps current behavior — `transcription.yaml` / `omni.yaml` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)