### PR TITLE
Add ta dev build-swift-weights CLI command

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -301,6 +301,75 @@ def download_musan(
     )
 
 
+SWIFT_RESOURCES_MODEL_DIR = Path("swift/Sources/TinyAudio/Resources/Model")
+
+
+@app.command("build-swift-weights")
+def build_swift_weights(
+    source_repo: str = typer.Option(
+        "mazesmazes/tiny-audio-embedded",
+        "--source-repo",
+        help="Tiny-audio embedded checkpoint to load encoder + projector from.",
+    ),
+    decoder_repo: str = typer.Option(
+        "Qwen/Qwen3-0.6B-MLX-4bit",
+        "--decoder-repo",
+        help="Upstream MLX decoder repo to mirror (weights, tokenizer, config).",
+    ),
+    dest: Path = typer.Option(
+        SWIFT_RESOURCES_MODEL_DIR,
+        "--dest",
+        help="Where to install the bundle. Default: the Swift package's Resources/Model.",
+    ),
+    push: bool = typer.Option(
+        False, "--push", help="Also push the bundle to a HuggingFace Hub repo."
+    ),
+    target_repo: str = typer.Option(
+        "mazesmazes/tiny-audio-mlx",
+        "--target-repo",
+        help="Hub repo to push to when --push is set.",
+    ),
+):
+    """Build the MLX bundle (encoder + projector + mirrored decoder + manifest)
+    and install it into the Swift package so `Transcriber.load()` finds it.
+
+    One command for the full Swift-weights build: re-quantizes the encoder,
+    re-saves the projector, mirrors the decoder/tokenizer/config from the
+    upstream Qwen MLX repo, writes config.json + manifest.json, and copies
+    everything into ``swift/Sources/TinyAudio/Resources/Model``. Pass --push
+    to also publish to the Hub.
+    """
+    import shutil
+    import tempfile
+
+    from scripts.publish_mlx_bundle import build_bundle
+
+    dest = dest.expanduser().resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="tiny-audio-mlx-") as work_str:
+        work = Path(work_str)
+        console.print(f"[bold]Building bundle[/bold] in {work}")
+        build_bundle(work, source_repo, decoder_repo)
+
+        console.print(f"[bold]Installing[/bold] bundle into {dest}")
+        for src in sorted(work.iterdir()):
+            if src.is_file():
+                shutil.copy(src, dest / src.name)
+
+        if push:
+            from huggingface_hub import HfApi
+
+            api = HfApi()
+            api.create_repo(target_repo, exist_ok=True)
+            console.print(f"[bold]Uploading[/bold] to {target_repo}")
+            api.upload_folder(folder_path=str(work), repo_id=target_repo)
+            console.print(f"[green]Pushed[/green] to https://huggingface.co/{target_repo}")
+
+    installed = sorted(p.name for p in dest.iterdir() if p.is_file())
+    console.print(f"[green]Done.[/green] {len(installed)} files at {dest}: {installed}")
+
+
 def _register_handler():
     from scripts.deploy.handler_local import test as handler_test
 

--- a/scripts/publish_mlx_bundle.py
+++ b/scripts/publish_mlx_bundle.py
@@ -52,10 +52,10 @@ def _save_module_safetensors(module, out_path: Path) -> None:
     mx.save_safetensors(str(out_path), flat)
 
 
-def build_bundle(work: Path, args) -> None:
+def build_bundle(work: Path, source_repo: str, decoder_repo: str) -> None:
     """Build the MLX bundle into *work*, writing all files except manifest.json last."""
-    print(f"Loading source MLX model from {args.source_repo}...")
-    model = MLXASRModel.from_pretrained(args.source_repo)
+    print(f"Loading source MLX model from {source_repo}...")
+    model = MLXASRModel.from_pretrained(source_repo)
 
     print("Saving encoder.safetensors (4-bit quantized)...")
     _save_module_safetensors(model.encoder, work / "encoder.safetensors")
@@ -63,8 +63,8 @@ def build_bundle(work: Path, args) -> None:
     print("Saving projector.safetensors (fp16)...")
     _save_module_safetensors(model.projector, work / "projector.safetensors")
 
-    print(f"Mirroring decoder weights from {args.decoder_repo}...")
-    decoder_src = Path(snapshot_download(args.decoder_repo))
+    print(f"Mirroring decoder weights from {decoder_repo}...")
+    decoder_src = Path(snapshot_download(decoder_repo))
     for name in ("model.safetensors", "tokenizer.json", "tokenizer_config.json", "config.json"):
         src = decoder_src / name
         if src.exists():
@@ -79,7 +79,7 @@ def build_bundle(work: Path, args) -> None:
         upstream_files = sorted(p.name for p in decoder_src.iterdir() if p.is_file())
         raise FileNotFoundError(
             f"Decoder mirror is missing required files: {missing}. "
-            f"Upstream {args.decoder_repo} contains: {upstream_files}. "
+            f"Upstream {decoder_repo} contains: {upstream_files}. "
             f"Sharded weights (model-XXXXX-of-NNNNN.safetensors) are not yet supported by this script."
         )
 
@@ -132,14 +132,14 @@ def main() -> None:
     if args.dry_run:
         work = Path(tempfile.mkdtemp(prefix="tiny-audio-mlx-"))
         print(f"Building bundle in {work}")
-        build_bundle(work, args)
+        build_bundle(work, args.source_repo, args.decoder_repo)
         print(f"Dry run — bundle prepared at {work}. Skipping push.")
         return
 
     with tempfile.TemporaryDirectory(prefix="tiny-audio-mlx-") as work_str:
         work = Path(work_str)
         print(f"Building bundle in {work}")
-        build_bundle(work, args)
+        build_bundle(work, args.source_repo, args.decoder_repo)
         api = HfApi()
         api.create_repo(args.target_repo, exist_ok=True)
         print(f"Uploading to {args.target_repo}...")


### PR DESCRIPTION
## Summary
- New `ta dev build-swift-weights` command runs the full Swift-weights build in one shot: re-quantizes the encoder, re-saves the projector, mirrors the Qwen3 decoder/tokenizer/config, writes `config.json` + `manifest.json`, and installs the bundle into `swift/Sources/TinyAudio/Resources/Model/`.
- Refactored `scripts/publish_mlx_bundle.py::build_bundle` to take explicit `source_repo` / `decoder_repo` args so it's importable from the CLI; the existing `python scripts/publish_mlx_bundle.py` entrypoint still works unchanged.
- Hub publishing is preserved via an opt-in `--push` flag (with `--target-repo`).

## Test plan
- [ ] `poetry run ta dev build-swift-weights --help` shows the new command and flags
- [ ] `poetry run ta dev build-swift-weights` populates `swift/Sources/TinyAudio/Resources/Model/` with the 8 expected files
- [ ] `swift test --package-path swift` still passes against the freshly-installed bundle
- [ ] `poetry run python scripts/publish_mlx_bundle.py --dry-run` (legacy entrypoint) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)