### PR TITLE
Simplify augmentation stack to NeMo-style MUSAN noise recipe

### DIFF
--- a/configs/data/multiasr.yaml
+++ b/configs/data/multiasr.yaml
@@ -142,7 +142,7 @@ datasets:
 
   # AMI corpus SDM - single distant mic (far-field). Natural size
   # (~107,319), target_samples omitted. Prior 168K target was 1.57x replay.
-  # With CHiME-6 / AliMeeting unavailable on HF, SDM + RIR/noise/speaker-mix
+  # With CHiME-6 / AliMeeting unavailable on HF, SDM + noise/speaker-mix
   # augmentation is the recipe for ami-sdm.
   - path: edinburghcstr/ami
     name: sdm

--- a/configs/experiments/embedded.yaml
+++ b/configs/experiments/embedded.yaml
@@ -31,12 +31,6 @@ training:
   # protecting general-LM behavior.
   decoder_learning_rate: 5e-5
   decoder_weight_decay: 0.001
-  # Projector is a small (~12M-param) randomly-initialized bridge that has to
-  # learn an exact mapping from the frozen encoder's space into the LM's
-  # embedding space; weight decay just pulls those bespoke directions back
-  # toward zero. The LM keeps its standard `weight_decay` (the trainer-args
-  # default applied to params not under `language_model.`).
-  projector_weight_decay: 0.0
   # Wider warmup gives the randomly-initialized projector time to settle before
   # the LM's much smaller LR starts to bite — important now that the LM is
   # trainable and the projector dominates early gradients.
@@ -70,9 +64,6 @@ training:
   # when Inductor's dynamic-shape backward is more robust on huge-vocab heads.
   torch_compile: true
 
-  # Standard 0.1 — speech-LLM-regime regularization. Prevents the LM from
-  # overfitting to high-frequency tokens in a 4.7M-sample mix.
-  label_smoothing_factor: 0.1
   weight_decay: 0.01
 
   # Probability of replacing a training sample's audio with silence + empty

--- a/configs/experiments/mps_smoke.yaml
+++ b/configs/experiments/mps_smoke.yaml
@@ -47,8 +47,6 @@ training:
   dataloader_prefetch_factor: null
   dataloader_pin_memory: false
 
-  rir_augmentation:
-    enabled: false
   noise_augmentation:
     enabled: false
 

--- a/configs/experiments/omni.yaml
+++ b/configs/experiments/omni.yaml
@@ -37,5 +37,4 @@ training:
   save_steps: 1000
   eval_steps: 1000
 
-  label_smoothing_factor: 0.1
   weight_decay: 0.01

--- a/configs/experiments/transcription.yaml
+++ b/configs/experiments/transcription.yaml
@@ -31,5 +31,4 @@ training:
   save_steps: 1000
   eval_steps: 1000
 
-  label_smoothing_factor: 0.1
   weight_decay: 0.0

--- a/configs/training/production.yaml
+++ b/configs/training/production.yaml
@@ -4,15 +4,9 @@ output_dir: ./outputs/production_model
 # Optimizer
 optim: adamw_torch_fused
 learning_rate: 1e-4
-max_grad_norm: 1.0
+max_grad_norm: 3.0
 warmup_steps: 2000
 lr_scheduler_type: cosine
-# β2=0.95 (vs HF default 0.999) — GPT-style recipe. The default's effective
-# variance window is ~1000 steps; with a randomly-initialized projector the
-# gradient distribution shifts hard in the first few thousand steps (i.e.
-# inside warmup), and a 1000-step variance estimate lags that shift. β2=0.95
-# tracks a ~20-step window so AdamW adapts quickly during warmup.
-adam_beta2: 0.95
 
 # Training
 max_steps: -1
@@ -70,112 +64,41 @@ dataloader_drop_last: true
 group_by_length: true
 length_column_name: duration
 
-# SpecAugment — 2×100 time masks. Closer to NeMo Canary's 10×100 mask
-# *length* but with far fewer masks; total budget is 200 frames (down from
-# the 4×70=280 we were running, well under encoder-recipe 1000). Larger
-# individual masks force the projector to span gaps in the encoder's
-# response rather than treating each masked window as an isolated gap.
-# Freq settings unchanged.
-use_specaugment: true
-num_time_masks: 2
-time_mask_length: 100
-num_freq_masks: 2
-freq_mask_length: 27
-
-# Gain perturbation — scale the waveform by a random gain in dB. Runs FIRST
-# so noise SNR randomization is computed against the post-gain level, which
-# matches deployment audio (variable mic gain + variable noise floor).
-gain_perturbation:
-  enabled: true
-  min_gain_db: -6.0   # NeMo runs ±10, Kaldi ~±18, audiomentations default ±12
-  max_gain_db: 6.0    # ±6 is the conservative speech-LLM-friendly range; pairs
-                      # well with noise SNR randomization since absolute level
-                      # variance compounds with relative SNR variance
-  prob: 0.5           # half-batch — matches noise / speed perturb cadence
-
-# Speed perturbation — resample source audio at a discrete factor to expose
-# the projector to the encoder's response across speaker rates. Standard
-# ASR augmentation in NeMo / Wav2Vec2 / Whisper-fine-tune recipes; cheap
-# effective-data multiplier (≈3× when factor=1.0 is in the set). Runs after
-# gain perturbation so the noise SNR is computed against gain-and-rate-varied
-# source audio.
-speed_perturbation:
-  enabled: true
-  # {0.9, 1.0, 1.1} is the canonical NeMo / Kaldi speed-perturb set. Wider
-  # ranges (e.g. {0.85, 1.0, 1.15}) push prosody beyond what Whisper's
-  # frozen encoder cleanly handles; stick with the standard.
-  factors: [0.9, 1.0, 1.1]
-  # 0.5: standard prob; lower than encoder-pretrain recipes (which run 1.0
-  # with a 3× sample budget) because we don't have the encoder capacity to
-  # absorb every batch being perturbed, but high enough to materially shift
-  # the prosody distribution the projector trains against.
-  prob: 0.5
-
-# RIR (Room Impulse Response) augmentation — simulates far-field / reverberant
-# audio by convolving with a random RIR sampled from a pool. Two backends:
-#   * corpus_path set — load real RIRs from a directory of WAV files
-#     (recommended; SOTA recipe used by NeMo / Canary / Parakeet). Run
-#     `ta dev download-rirs` to fetch OpenSLR-28 to ~/.cache/openslr-28.
-#   * corpus_path null — generate synthetic RIRs at init via pyroomacoustics'
-#     image-source method using the room / T60 ranges below. CPU-only,
-#     no corpus needed; less realistic.
-#
-# Range defaults mirror Interspeech 2024 / ICASSP 2025 ASR-robustness recipes
-# and only matter for the synthetic backend. prob 0.5 ensures roughly half of
-# every batch sees reverb without overwhelming clean-speech training signal.
-rir_augmentation:
-  enabled: true
-  # Combine OpenSLR-28's real RIRs with its much larger simulated_rirs set
-  # (~60K simulated impulses) so pool_size sub-samples from the full corpus
-  # each run. pointsource_noises is intentionally excluded — those are noise
-  # clips, not impulse responses.
-  corpus_path:
-    - ~/.cache/openslr-28/real_rirs_isotropic_noises
-    - ~/.cache/openslr-28/simulated_rirs
-  # Bumped from 2048 → 8192: sub-sampling 2K from ~60K simulated impulses was
-  # leaving real-RIR diversity on the table, especially relevant for ami-sdm.
-  pool_size: 8192
-  # Widened from [3, 10] / [2.4, 4] / t60 [0.1, 1.0] to capture larger meeting
-  # rooms with longer reverberation. Real AMI rooms are bigger and more
-  # reverberant than the prior synthetic distribution covered.
-  room_x_range: [3.0, 15.0]
-  room_y_range: [3.0, 15.0]
-  room_z_range: [2.4, 5.0]
-  t60_range: [0.2, 1.5]
-  # 0.6: aggressive reverb exposure. ami-sdm and Switchboard are the key
-  # eval gaps where reverberant / far-field training pays off; 0.6 keeps
-  # majority-of-batches reverb to invest projector capacity in those
-  # slices. Trades some LS Clean / Tedlium clean-speech headroom for that
-  # gain — eval will tell us whether the trade is favorable.
-  prob: 0.6
-  seed: null
-
-# Noise augmentation — mixes background noise into the signal via
-# torch-audiomentations. Two backends:
-#   * corpus_path set — AddBackgroundNoise samples a random clip from a
-#     directory of audio files (recommended; SOTA recipe). Run
-#     `ta dev download-musan` to fetch MUSAN to ~/.cache/musan.
-#   * corpus_path null — AddColoredNoise synthesizes white / pink / blue /
-#     violet noise. Cheap, no corpus, but lacks real-world structure.
-# CPU-friendly; chains after RIR in the dataloader transform pipeline.
-#
-# SNR range [0, 25] dB targets the natural-noise regime; floor held at 0 dB
-# since sub-zero-SNR samples were degrading the clean read-speech evals more
-# than they were buying robustness gains.
+# Noise augmentation — Persian-ELN recipe (arXiv:2512.17247): every utterance
+# corrupted with one MUSAN ambient segment at SNR ∈ [-15, +15] dB, plus a thin
+# layer of low-amplitude Gaussian noise on top. Music/speech/babble subsets
+# are excluded; only the ~930-clip ambient noise subset is used.
 noise_augmentation:
   enabled: true
-  # MUSAN (music + speech + noise, ~109h) plus OpenSLR-28's pointsource_noises
-  # (~843 clips) — the canonical Kaldi/NeMo noise pool.
+  # MUSAN ambient subset only (`musan/noise` — ~930 wav, ~6 hours: rain,
+  # thunder, wind, crowd chatter, cafeteria, footsteps, paper, mechanical,
+  # phone tones). Excludes `musan/music` and `musan/speech` (babble).
   corpus_path:
-    - ~/.cache/musan/musan
-    - ~/.cache/openslr-28/pointsource_noises
-  # 0.7 → 0.5: speech-LLM regime; noise no longer dominates batches but stays
-  # at meaningful exposure (Qwen2-Audio / Granite-Speech run ~0.2-0.5).
-  # 0.5 hedges between full speech-LLM defaults (~0.3) and preserving the
-  # robustness gains the prior 0.7 was paying for.
-  prob: 0.5
-  min_snr_db: 0.0
-  max_snr_db: 25.0
+    - ~/.cache/musan/musan/noise
+  # Apply to every utterance (paper applies noise corruption to all training
+  # samples, not a fraction).
+  prob: 1.0
+  min_snr_db: -15.0
+  max_snr_db: 15.0
+  # NeMo NoisePerturbationWithNormalization: normalize both clean and noise
+  # to this dB-FS target before SNR scaling. Decouples SNR from per-clip
+  # absolute level (close-talk vs. distant-mic AMI). -25 dBFS is NeMo's
+  # default and matches the Microsoft DNS-Challenge convention.
+  target_db: -25.0
+  # Floor for the RMS divide in dB-FS normalization (effectively silent
+  # clips snap to this RMS instead of dividing by ~0). NeMo default.
+  rms_epsilon: 0.01
+  # Insert this much silence between repeats when a noise clip is shorter
+  # than the utterance — avoids the periodic seam artifact that butt-joined
+  # tiling creates on short MUSAN clips.
+  tile_silence_sec: 0.25
+  # Additive Gaussian "background sensor" noise layered on top of the MUSAN
+  # mix. SNR sampled uniformly per clip and σ derived from clip RMS
+  # (SpeechBrain / NeMo additive-noise convention). Paper doesn't specify
+  # SNR — 20-40 dB is the canonical "background dither" range, with MUSAN
+  # remaining the dominant noise component. Set both to null to disable.
+  gaussian_min_snr_db: 20.0
+  gaussian_max_snr_db: 40.0
 
 # Misc
 disable_tqdm: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -1294,55 +1294,6 @@ files = [
 ]
 
 [[package]]
-name = "cython"
-version = "3.2.4"
-description = "The Cython compiler for writing C extensions in the Python language."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "cython-3.2.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02cb0cc0f23b9874ad262d7d2b9560aed9c7e2df07b49b920bda6f2cc9cb505e"},
-    {file = "cython-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f136f379a4a54246facd0eb6f1ee15c3837cb314ce87b677582ec014db4c6845"},
-    {file = "cython-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:35ab0632186057406ec729374c737c37051d2eacad9d515d94e5a3b3e58a9b02"},
-    {file = "cython-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:ca2399dc75796b785f74fb85c938254fa10c80272004d573c455f9123eceed86"},
-    {file = "cython-3.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff9af2134c05e3734064808db95b4dd7341a39af06e8945d05ea358e1741aaed"},
-    {file = "cython-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67922c9de058a0bfb72d2e75222c52d09395614108c68a76d9800f150296ddb3"},
-    {file = "cython-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b362819d155fff1482575e804e43e3a8825332d32baa15245f4642022664a3f4"},
-    {file = "cython-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:1a64a112a34ec719b47c01395647e54fb4cf088a511613f9a3a5196694e8e382"},
-    {file = "cython-3.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64d7f71be3dd6d6d4a4c575bb3a4674ea06d1e1e5e4cd1b9882a2bc40ed3c4c9"},
-    {file = "cython-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:869487ea41d004f8b92171f42271fbfadb1ec03bede3158705d16cd570d6b891"},
-    {file = "cython-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:55b6c44cd30821f0b25220ceba6fe636ede48981d2a41b9bbfe3c7902ce44ea7"},
-    {file = "cython-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:767b143704bdd08a563153448955935844e53b852e54afdc552b43902ed1e235"},
-    {file = "cython-3.2.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:28e8075087a59756f2d059273184b8b639fe0f16cf17470bd91c39921bc154e0"},
-    {file = "cython-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03893c88299a2c868bb741ba6513357acd104e7c42265809fd58dce1456a36fc"},
-    {file = "cython-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f81eda419b5ada7b197bbc3c5f4494090e3884521ffd75a3876c93fbf66c9ca8"},
-    {file = "cython-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:83266c356c13c68ffe658b4905279c993d8a5337bb0160fa90c8a3e297ea9a2e"},
-    {file = "cython-3.2.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4b4fd5332ab093131fa6172e8362f16adef3eac3179fd24bbdc392531cb82fa"},
-    {file = "cython-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3b5ac54e95f034bc7fb07313996d27cbf71abc17b229b186c1540942d2dc28e"},
-    {file = "cython-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f43be4eaa6afd58ce20d970bb1657a3627c44e1760630b82aa256ba74b4acb"},
-    {file = "cython-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:983f9d2bb8a896e16fa68f2b37866ded35fa980195eefe62f764ddc5f9f5ef8e"},
-    {file = "cython-3.2.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:55eb425c0baf1c8a46aa4424bc35b709db22f3c8a1de33adb3ecb8a3d54ea42a"},
-    {file = "cython-3.2.4-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f583cad7a7eed109f0babb5035e92d0c1260598f53add626a8568b57246b62c3"},
-    {file = "cython-3.2.4-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:72e6c0bbd978e2678b45351395f6825b9b8466095402eae293f4f7a73e9a3e85"},
-    {file = "cython-3.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:14dae483ca2838b287085ff98bc206abd7a597b7bb16939a092f8e84d9062842"},
-    {file = "cython-3.2.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:36bf3f5eb56d5281aafabecbaa6ed288bc11db87547bba4e1e52943ae6961ccf"},
-    {file = "cython-3.2.4-cp39-abi3-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6d5267f22b6451eb1e2e1b88f6f78a2c9c8733a6ddefd4520d3968d26b824581"},
-    {file = "cython-3.2.4-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3b6e58f73a69230218d5381817850ce6d0da5bb7e87eb7d528c7027cbba40b06"},
-    {file = "cython-3.2.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e71efb20048358a6b8ec604a0532961c50c067b5e63e345e2e359fff72feaee8"},
-    {file = "cython-3.2.4-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:28b1e363b024c4b8dcf52ff68125e635cb9cb4b0ba997d628f25e32543a71103"},
-    {file = "cython-3.2.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:31a90b4a2c47bb6d56baeb926948348ec968e932c1ae2c53239164e3e8880ccf"},
-    {file = "cython-3.2.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e65e4773021f8dc8532010b4fbebe782c77f9a0817e93886e518c93bd6a44e9d"},
-    {file = "cython-3.2.4-cp39-abi3-win32.whl", hash = "sha256:2b1f12c0e4798293d2754e73cd6f35fa5bbdf072bdc14bc6fc442c059ef2d290"},
-    {file = "cython-3.2.4-cp39-abi3-win_arm64.whl", hash = "sha256:3b8e62049afef9da931d55de82d8f46c9a147313b69d5ff6af6e9121d545ce7a"},
-    {file = "cython-3.2.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f8d685a70bce39acc1d62ec3916d9b724b5ef665b0ce25ae55e1c85ee09747fc"},
-    {file = "cython-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca578c9cb872c7ecffbe14815dc4590a003bc13339e90b2633540c7e1a252839"},
-    {file = "cython-3.2.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b84d4e3c875915545f77c88dba65ad3741afd2431e5cdee6c9a20cefe6905647"},
-    {file = "cython-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:fdfdd753ad7e18e5092b413e9f542e8d28b8a08203126090e1c15f7783b7fe57"},
-    {file = "cython-3.2.4-py3-none-any.whl", hash = "sha256:732fc93bc33ae4b14f6afaca663b916c2fdd5dcbfad7114e17fb2434eeaea45c"},
-    {file = "cython-3.2.4.tar.gz", hash = "sha256:84226ecd313b233da27dc2eb3601b4f222b8209c3a7216d8733b031da1dc64e6"},
-]
-
-[[package]]
 name = "datasets"
 version = "3.6.0"
 description = "HuggingFace community-driven open-source library of datasets"
@@ -4999,21 +4950,6 @@ files = [
 test = ["numpy"]
 
 [[package]]
-name = "pybind11"
-version = "3.0.4"
-description = "Seamless operability between C++11 and Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "pybind11-3.0.4-py3-none-any.whl", hash = "sha256:961720ee652da51d531b7b2451a6bd2bc042b0106e6d9baa48ecb7d58034ce63"},
-    {file = "pybind11-3.0.4.tar.gz", hash = "sha256:3286b59c8a774b9ee650169302dd5a4eedc30a8617905a0560dd8ee44775130c"},
-]
-
-[package.extras]
-global = ["pybind11-global (==3.0.4)"]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
@@ -5351,36 +5287,6 @@ typing-extensions = ">=4.1"
 all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
 nodejs = ["nodejs-wheel-binaries"]
-
-[[package]]
-name = "pyroomacoustics"
-version = "0.10.0"
-description = "A simple framework for room acoustics and audio processing in Python."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pyroomacoustics-0.10.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bbf2576cfe82ace938d04489168d3c438ae748207d9e02eb8850d8f291018856"},
-    {file = "pyroomacoustics-0.10.0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:ebcda3db0746673442a21e42d9823b95036cef084f69d0bca0df28b57030e21a"},
-    {file = "pyroomacoustics-0.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:3ee3ed71e13eb0d6f83c88ff9d3371f0392f617f9f5184155391ec3bcbec1237"},
-    {file = "pyroomacoustics-0.10.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c73b5be3291b5f338405564c5d05496a94512eb8843548fb65811f1c7163994"},
-    {file = "pyroomacoustics-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb2bdebc99a9c88264cd0b953aeb44c9d383bff5154b5a09cecdad8ce0c48ac6"},
-    {file = "pyroomacoustics-0.10.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9927393faa66d469415f941b989ba671feb73e19bc684a439c217f661df22071"},
-    {file = "pyroomacoustics-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:aa20100db778a3ae92aaf5e4ee1578d9e328d6298e82d63621c1f60fc273ac74"},
-    {file = "pyroomacoustics-0.10.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c91a7f380b640023125374f2d984b33dfc63c842acf66fc606919d4e9ffd4b40"},
-    {file = "pyroomacoustics-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:cd9eaaa4b2b035ce41a40141e5e295fb1060476d0fd7ca3cc3a37f4f2de81362"},
-    {file = "pyroomacoustics-0.10.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e539cce9e93c1a1e6d5289be2eebd756c0490c93fc68cad688dbab566061b16f"},
-    {file = "pyroomacoustics-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:a7cea47b80329f368345d303450c4614eaf4236464bd5ae7ab1c6d0d7af7fc3a"},
-    {file = "pyroomacoustics-0.10.0-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:a7f19f8449000839227bf36b87491f25110d759e435cec8f12f7138b7f4a5135"},
-    {file = "pyroomacoustics-0.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a5bd80253b56092280d9011ad75abe3ec7d3d3de757b2ed5d28a9781724502f1"},
-    {file = "pyroomacoustics-0.10.0.tar.gz", hash = "sha256:e683f28f7f3511d92fe6f111f35a68d76828f18b9c6668ef5ed4b3e8ca9c3219"},
-]
-
-[package.dependencies]
-Cython = "*"
-numpy = ">=1.13.0"
-pybind11 = ">=2.2"
-scipy = ">=0.18.0"
 
 [[package]]
 name = "pytest"
@@ -8353,4 +8259,4 @@ mlx = ["mlx", "mlx-audio", "mlx-lm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "054e7168338514fefe279feea77c6b8e4df361616a3dc0fefd9b381268dc58cc"
+content-hash = "504b7f2f0faf74e8890fab8afaab9be49f6bd9cfdcbec54288366c4dfc052d86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ ten-vad = ">=1.0.6"
 speechbrain = {git = "https://github.com/speechbrain/speechbrain.git"}
 pytz = "*"
 torch-audiomentations = ">=0.12.0,<0.13.0"
-pyroomacoustics = ">=0.7.0"
 
 [project.optional-dependencies]
 local = ["pyaudio>=0.2.14"]

--- a/scripts/debug/analyze_weights.py
+++ b/scripts/debug/analyze_weights.py
@@ -296,7 +296,6 @@ def analyze_weights(
         "projector_pool_stride",
         "audio_model_id",
         "text_model_id",
-        "use_specaugment",
         "use_lora",
     ]
     for key in important_keys:

--- a/scripts/debug/check_gradient_flow.py
+++ b/scripts/debug/check_gradient_flow.py
@@ -31,20 +31,38 @@ from tiny_audio.asr_config import ASRConfig
 from tiny_audio.asr_modeling import ASRModel
 
 
-def build_model(dtype: torch.dtype, device: str) -> ASRModel:
-    """Mirror configs/experiments/embedded.yaml model section."""
-    cfg = ASRConfig(
-        audio_model_id="zai-org/GLM-ASR-Nano-2512",
-        text_model_id="Qwen/Qwen3-0.6B",
-        projector_type="mlp",
-        projector_pool_stride=4,
-        projector_hidden_dim=2048,
-        freeze_language_model=False,
-        # Use eager so we don't depend on flash-attn being importable on the
-        # local box; gradient flow is independent of attention impl.
-        attn_implementation="eager",
-    )
-    model = ASRModel(cfg)
+def build_model(dtype: torch.dtype, device: str, model_id: str | None = None) -> ASRModel:
+    """Build the model used by configs/experiments/embedded.yaml.
+
+    If `model_id` is provided, load the trained checkpoint from the Hub or a
+    local path; otherwise build a fresh model with base-LM weights and a
+    randomly-initialized projector. Gradient flow (which params get grads)
+    is independent of weights, but absolute gradient magnitudes — and the
+    projector/decoder ratio — depend on the trained state, so checkpoint
+    loading matters for the "is the projector dominating?" diagnostic.
+    """
+    if model_id is None:
+        cfg = ASRConfig(
+            audio_model_id="zai-org/GLM-ASR-Nano-2512",
+            text_model_id="Qwen/Qwen3-0.6B",
+            projector_type="mlp",
+            projector_pool_stride=4,
+            projector_hidden_dim=2048,
+            freeze_language_model=False,
+            # Use eager so we don't depend on flash-attn being importable on the
+            # local box; gradient flow is independent of attention impl.
+            attn_implementation="eager",
+        )
+        model = ASRModel(cfg)
+    else:
+        model = ASRModel.from_pretrained(
+            model_id,
+            attn_implementation="eager",
+        )
+        # from_pretrained may have left freeze_language_model=True from the
+        # saved config; force it off so the LM gets gradient as in training.
+        for p in model.language_model.parameters():
+            p.requires_grad_(True)
     model.to(device=device, dtype=dtype)
     return model
 
@@ -272,18 +290,42 @@ def report(model: ASRModel, dtype: torch.dtype, device: str) -> None:
         print("         - all grads finite")
 
 
-def main() -> None:
+def main(
+    model_id: str | None = None,
+    dtype: str = "float32",
+    device: str = "cpu",
+) -> None:
+    """Run gradient-flow probe.
+
+    Args:
+        model_id: Hub repo id or local path to a trained checkpoint. If
+            omitted, build a fresh model from base-LM weights + randomly-
+            initialized projector (verifies plumbing, not training state).
+        dtype: float32 / bfloat16 / float16.
+        device: cpu / cuda / mps.
+    """
+    torch_dtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[dtype]
+    torch.manual_seed(0)
+    model = build_model(torch_dtype, device, model_id=model_id)
+    report(model, torch_dtype, device)
+
+
+def _argparse_main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model-id",
+        default=None,
+        help="Hub repo id or local path; omit to build a fresh model.",
+    )
     parser.add_argument("--dtype", default="float32", choices=["float32", "bfloat16", "float16"])
     parser.add_argument("--device", default="cpu")
     args = parser.parse_args()
-    dtype = {"float32": torch.float32, "bfloat16": torch.bfloat16, "float16": torch.float16}[
-        args.dtype
-    ]
-    torch.manual_seed(0)
-    model = build_model(dtype, args.device)
-    report(model, dtype, args.device)
+    main(model_id=args.model_id, dtype=args.dtype, device=args.device)
 
 
 if __name__ == "__main__":
-    main()
+    _argparse_main()

--- a/scripts/debug/cli.py
+++ b/scripts/debug/cli.py
@@ -5,6 +5,7 @@ import typer
 
 from scripts.debug.analyze_lora import main as analyze_lora_command
 from scripts.debug.analyze_weights import main as analyze_weights_command
+from scripts.debug.check_gradient_flow import main as check_gradient_flow_command
 from scripts.debug.check_moe import main as check_moe_command
 from scripts.debug.check_mosa import main as check_mosa_command
 from scripts.debug.compare_to_base import main as compare_to_base_command
@@ -24,6 +25,10 @@ app.command(name="analyze-weights", help="Analyze model weights for training hea
 app.command(name="compare-to-base", help="Compare fine-tuned weights against base model")(
     compare_to_base_command
 )
+app.command(
+    name="check-gradient-flow",
+    help="Probe gradient flow on a checkpoint (per-component grad norms)",
+)(check_gradient_flow_command)
 
 if __name__ == "__main__":
     app()

--- a/scripts/deploy/runpod.py
+++ b/scripts/deploy/runpod.py
@@ -168,20 +168,18 @@ def setup_remote_environment(conn: Connection) -> None:
     )
     # Optional perf adds — fall back gracefully on pods where these aren't
     # available (e.g. minimal images, universe repo disabled, partial apt
-    # cache). aria2 → faster RIRs/MUSAN download (urllib fallback exists);
+    # cache). aria2 → faster MUSAN download (urllib fallback exists);
     # pigz → parallel gzip for MUSAN tar (single-threaded fallback);
-    # p7zip-full → parallel zip extract for OpenSLR-28 (unzip fallback);
     # portaudio19-dev → only needed for pyaudio runtime, never training.
     conn.run(
-        "apt-get install -y aria2 pigz p7zip-full portaudio19-dev || true",
+        "apt-get install -y aria2 pigz portaudio19-dev || true",
     )
     # Pin augmentation corpora onto the persistent /workspace volume so they
-    # survive container restarts. ~/.cache/<name> becomes a symlink, which
-    # keeps `corpus_path: ~/.cache/...` in production.yaml portable across
-    # local dev and RunPod without per-environment config branches.
+    # survive container restarts. ~/.cache/musan becomes a symlink, which
+    # keeps `corpus_path: ~/.cache/musan/...` in production.yaml portable
+    # across local dev and RunPod without per-environment config branches.
     conn.run(
-        "mkdir -p /workspace/.cache/openslr-28 /workspace/.cache/musan /root/.cache && "
-        "ln -sfn /workspace/.cache/openslr-28 /root/.cache/openslr-28 && "
+        "mkdir -p /workspace/.cache/musan /root/.cache && "
         "ln -sfn /workspace/.cache/musan /root/.cache/musan",
     )
     print("Remote environment setup complete!")
@@ -279,11 +277,6 @@ def _download_corpus(conn: Connection, label: str, ta_subcommand: str) -> None:
     print(f"{label} ready.")
 
 
-def download_rirs(conn: Connection) -> None:
-    """Download OpenSLR-28 to ~/.cache/openslr-28 on the remote."""
-    _download_corpus(conn, "RIR corpus (OpenSLR-28)", "download-rirs")
-
-
 def download_musan(conn: Connection) -> None:
     """Download MUSAN to ~/.cache/musan on the remote."""
     _download_corpus(conn, "noise corpus (MUSAN)", "download-musan")
@@ -297,9 +290,6 @@ def deploy(
     skip_sync: bool = typer.Option(False, "--skip-sync", help="Skip project file sync"),
     skip_deps: bool = typer.Option(
         False, "--skip-deps", help="Skip Python dependency installation"
-    ),
-    skip_rirs: bool = typer.Option(
-        False, "--skip-rirs", help="Skip OpenSLR-28 RIR corpus download"
     ),
     skip_musan: bool = typer.Option(False, "--skip-musan", help="Skip MUSAN noise corpus download"),
 ):
@@ -319,9 +309,6 @@ def deploy(
 
     if not skip_deps:
         install_dependencies(conn)
-
-    if not skip_rirs:
-        download_rirs(conn)
 
     if not skip_musan:
         download_musan(conn)

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -148,18 +148,15 @@ def docstrings():
     raise typer.Exit(run("interrogate", LIB_PATH, "-v", "--fail-under", "50"))
 
 
-OPENSLR28_URL = "https://www.openslr.org/resources/28/rirs_noises.zip"
-OPENSLR28_DEFAULT_DIR = Path.home() / ".cache" / "openslr-28"
-
 MUSAN_URL = "https://www.openslr.org/resources/17/musan.tar.gz"
 MUSAN_DEFAULT_DIR = Path.home() / ".cache" / "musan"
 
 
 def _extract_archive(archive_path: Path, target_dir: Path) -> None:
     # Shell out to `unzip` / `tar`: 2-5x faster than Python's pure-Python
-    # zipfile / tarfile on archives with many small files (OpenSLR-28's ~60K
-    # simulated RIRs), and per-file stdout output makes long extractions
-    # visibly progressing instead of looking hung.
+    # zipfile / tarfile on archives with many small files, and per-file
+    # stdout output makes long extractions visibly progressing instead of
+    # looking hung.
     import shutil
     import subprocess
 
@@ -278,47 +275,6 @@ def _download_corpus(
     console.print(
         f"[green]Done.[/green] {wav_count} {asset_label} at {sentinel}. "
         f"Set {config_field} to this path."
-    )
-
-
-def _flatten_openslr28(target_dir: Path) -> None:
-    import shutil
-
-    extracted_root = target_dir / "RIRS_NOISES"
-    if not extracted_root.exists():
-        return
-    for sub in ("real_rirs_isotropic_noises", "pointsource_noises", "simulated_rirs"):
-        src = extracted_root / sub
-        dst = target_dir / sub
-        if src.exists() and not dst.exists():
-            shutil.move(str(src), str(dst))
-    shutil.rmtree(extracted_root, ignore_errors=True)
-
-
-@app.command("download-rirs")
-def download_rirs(
-    target_dir: Path = typer.Option(
-        OPENSLR28_DEFAULT_DIR,
-        "--target-dir",
-        "-t",
-        help="Directory to extract OpenSLR-28 into (default: ~/.cache/openslr-28).",
-    ),
-    force: bool = typer.Option(False, "--force", help="Re-download even if already present."),
-):
-    """Download OpenSLR-28 (real RIRs + point-source noise, ~1 GB).
-
-    Used by RIRAugmentation when ``corpus_path`` points at the extracted
-    real_rirs_isotropic_noises subset.
-    """
-    _download_corpus(
-        url=OPENSLR28_URL,
-        target_dir=target_dir,
-        archive_name="rirs_noises.zip",
-        sentinel_subdir="real_rirs_isotropic_noises",
-        asset_label="real RIRs",
-        config_field="rir_augmentation.corpus_path",
-        force=force,
-        post_extract=_flatten_openslr28,
     )
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -37,12 +37,7 @@ from tiny_audio.asr_config import (
     compute_encoder_output_length,
 )
 from tiny_audio.asr_modeling import ASRModel
-from tiny_audio.augmentation import (
-    GainPerturbationAugmentation,
-    NoiseAugmentation,
-    RIRAugmentation,
-    SpeedPerturbationAugmentation,
-)
+from tiny_audio.augmentation import NoiseAugmentation
 
 TRANSCRIBE_PROMPTS = ["Transcribe the speech to text"]
 DESCRIBE_PROMPTS = ["Describe all the information you can hear"]
@@ -409,69 +404,6 @@ class ASRTrainer(Trainer):
         self.optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
         return self.optimizer
 
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        """Compute label-smoothed CE with token-correct accumulation.
-
-        HuggingFace Trainer's built-in ``label_smoother`` checks
-        MODEL_FOR_CAUSAL_LM_MAPPING_NAMES to decide whether to shift labels;
-        since ASRModel isn't in that mapping, it incorrectly uses
-        shift_labels=False, producing misaligned predictions. This override
-        shifts labels manually and applies smoothing via
-        ``CrossEntropyLoss(label_smoothing=)`` directly.
-
-        ``num_items_in_batch`` is the total non-ignored target-token count
-        across the gradient-accumulation window (threaded through by HF
-        Trainer in newer transformers versions). When provided, CE uses
-        ``reduction='sum'`` and divides by it for token-correct accumulated
-        gradients — samples don't get up-weighted just for being short.
-        When absent, falls back to per-micro-batch mean + accum-step
-        division (the legacy formulation).
-
-        Projector aux loss (MoSA / MoE only; None for MLP) is a per-batch
-        regularizer, not a per-token quantity — kept on the accum-step
-        normalization path regardless of which CE reduction ran.
-        """
-        labels = inputs.pop("labels", None)
-        if labels is None:
-            outputs = model(**inputs)
-            loss = outputs.loss
-            return (loss, outputs) if return_outputs else loss
-
-        outputs = model(**inputs)
-        logits = outputs.logits
-
-        shift_logits = logits[..., :-1, :].contiguous()
-        shift_labels = labels[..., 1:].contiguous().to(logits.device)
-        flat_logits = shift_logits.view(-1, shift_logits.size(-1))
-        flat_labels = shift_labels.view(-1)
-
-        token_correct = num_items_in_batch is not None
-        reduction = "sum" if token_correct else "mean"
-
-        loss_fct = torch.nn.CrossEntropyLoss(
-            ignore_index=-100,
-            label_smoothing=float(self.args.label_smoothing_factor),
-            reduction=reduction,
-        )
-        loss = loss_fct(flat_logits, flat_labels)
-
-        if token_correct:
-            loss = loss / num_items_in_batch
-        elif self.args.gradient_accumulation_steps > 1:
-            loss = loss / self.args.gradient_accumulation_steps
-
-        projector = getattr(model, "projector", None)
-        if projector is not None and hasattr(projector, "get_aux_loss"):
-            aux_loss = projector.get_aux_loss()
-            if aux_loss is not None and aux_loss.numel() > 0:
-                aux = aux_loss.to(loss.device)
-                if self.args.gradient_accumulation_steps > 1:
-                    aux = aux / self.args.gradient_accumulation_steps
-                loss = loss + aux
-
-        outputs.loss = loss
-        return (loss, outputs) if return_outputs else loss
-
 
 class PushToHubCallback(TrainerCallback):
     """Pushes model to Hub on every save."""
@@ -501,11 +433,6 @@ def get_valid_training_args(config: dict) -> dict:
 
 
 TRAINING_MODEL_PARAMS = [
-    "use_specaugment",
-    "num_time_masks",
-    "time_mask_length",
-    "num_freq_masks",
-    "freq_mask_length",
     "attn_implementation",
     "use_lora",
     "lora_rank",
@@ -563,48 +490,6 @@ def main(cfg: DictConfig) -> None:
 
     augmentations: list = []
 
-    # Gain perturbation runs FIRST so downstream noise SNR is computed against
-    # the post-gain level — matches deployment audio (variable mic gain +
-    # variable noise floor).
-    gain_cfg = cfg.training.get("gain_perturbation") or {}
-    if gain_cfg.get("enabled"):
-        augmentations.append(
-            GainPerturbationAugmentation(
-                min_gain_db=gain_cfg.get("min_gain_db", -6.0),
-                max_gain_db=gain_cfg.get("max_gain_db", 6.0),
-                prob=gain_cfg.get("prob", 0.5),
-            )
-        )
-
-    # Speed perturbation runs FIRST in the chain — it models source-signal
-    # variation (speaker rate), then RIR / noise model the channel applied
-    # to that varied source. Standard NeMo / Wav2Vec2 order.
-    speed_cfg = cfg.training.get("speed_perturbation") or {}
-    if speed_cfg.get("enabled"):
-        augmentations.append(
-            SpeedPerturbationAugmentation(
-                sample_rate=cfg.data.sample_rate,
-                factors=tuple(speed_cfg.get("factors", [0.9, 1.0, 1.1])),
-                prob=speed_cfg.get("prob", 0.5),
-            )
-        )
-
-    rir_aug: RIRAugmentation | None = None
-    rir_cfg = cfg.training.get("rir_augmentation") or {}
-    if rir_cfg.get("enabled"):
-        rir_aug = RIRAugmentation(
-            sample_rate=cfg.data.sample_rate,
-            prob=rir_cfg.get("prob", 0.5),
-            pool_size=rir_cfg.get("pool_size", 2048),
-            corpus_path=rir_cfg.get("corpus_path"),
-            room_x_range=tuple(rir_cfg.get("room_x_range", [3.0, 10.0])),
-            room_y_range=tuple(rir_cfg.get("room_y_range", [3.0, 10.0])),
-            room_z_range=tuple(rir_cfg.get("room_z_range", [2.4, 4.0])),
-            t60_range=tuple(rir_cfg.get("t60_range", [0.1, 1.0])),
-            seed=rir_cfg.get("seed"),
-        )
-        augmentations.append(rir_aug)
-
     noise_aug: NoiseAugmentation | None = None
     noise_cfg = cfg.training.get("noise_augmentation") or {}
     if noise_cfg.get("enabled"):
@@ -614,6 +499,11 @@ def main(cfg: DictConfig) -> None:
             min_snr_db=noise_cfg.get("min_snr_db", 0.0),
             max_snr_db=noise_cfg.get("max_snr_db", 25.0),
             corpus_path=noise_cfg.get("corpus_path"),
+            gaussian_min_snr_db=noise_cfg.get("gaussian_min_snr_db"),
+            gaussian_max_snr_db=noise_cfg.get("gaussian_max_snr_db"),
+            target_db=noise_cfg.get("target_db", -25.0),
+            rms_epsilon=noise_cfg.get("rms_epsilon", 1e-2),
+            tile_silence_sec=noise_cfg.get("tile_silence_sec", 0.25),
         )
         augmentations.append(noise_aug)
 
@@ -638,9 +528,7 @@ def main(cfg: DictConfig) -> None:
                 # clear text. Targets the AMI backchannel hallucinations
                 # ("yeah" / "huh" on empty GT) by teaching the model to emit
                 # only EOS on non-speech. Falls through to the rest of the
-                # augmentation chain so RIR still applies — at inference,
-                # real silence has been through a room, and the training
-                # distribution should match.
+                # augmentation chain so noise mixing still applies.
                 if (
                     silence_injection_prob > 0.0
                     and noise_aug is not None

--- a/swift/Sources/TinyAudio/Resources/Model/decoder.safetensors
+++ b/swift/Sources/TinyAudio/Resources/Model/decoder.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c307bba124847aa74eb789c3060bb631c65d694751117fd32af5bb0d23584f3
-size 633153630
+oid sha256:af71197cf0dc561a7051ccd8822dd5dcf4b60f3de6922f9eed15d13a8db1196f
+size 670516209

--- a/swift/Sources/TinyAudio/Resources/Model/decoder_config.json
+++ b/swift/Sources/TinyAudio/Resources/Model/decoder_config.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9330914377dc1928ab370c53c2ddf63ab6e501b0190f86b38717fdec2f58db4f
-size 1866
+oid sha256:c4bd36afe6c145fc8bf7fb67bd95c46f5eaabfe9f0a2413b2ea2564afee6c6ed
+size 1865

--- a/swift/Sources/TinyAudio/Resources/Model/manifest.json
+++ b/swift/Sources/TinyAudio/Resources/Model/manifest.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1045b07d300e8fcca68dce13a85d57346ae998743424c156a6430f0cf029f456
+oid sha256:8c36705de1effb87327d519d9b243293d8da7a420e32fbf6605e7ce13454fb4d
 size 1023

--- a/swift/Sources/TinyAudio/Resources/Model/projector.safetensors
+++ b/swift/Sources/TinyAudio/Resources/Model/projector.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11db49749835d4c3d78da1eb064daef021516a1ab6c3cf31bd69e3b2998062f0
-size 25170190
+oid sha256:402edcf0e5c31a0bf561b59c4db9af326190be04eebe4b416013c9e1bd1ad84f
+size 50344282

--- a/tests/test_asr_modeling.py
+++ b/tests/test_asr_modeling.py
@@ -290,44 +290,6 @@ class TestGenerateStreaming:
             assert isinstance(piece, str)
 
 
-class TestForwardSpecAugment:
-    """forward applies SpecAugment when training and use_specaugment=True."""
-
-    def test_specaugment_applied_during_training(self):
-        from unittest.mock import patch
-
-        from tiny_audio.asr_config import ASRConfig
-        from tiny_audio.asr_modeling import ASRModel
-
-        cfg = ASRConfig(
-            audio_model_id="openai/whisper-tiny",
-            text_model_id="HuggingFaceTB/SmolLM2-135M-Instruct",
-            attn_implementation="eager",
-            model_dtype="float32",
-            use_specaugment=True,
-            num_time_masks=1,
-            time_mask_length=5,
-        )
-        model = ASRModel(cfg)
-        assert model.spec_augment is not None
-
-        model.train()
-
-        input_ids = torch.tensor([[model.audio_token_id, 1, 2]])
-        input_features = torch.zeros(1, 80, 3000)
-        audio_attention_mask = torch.ones(1, 3000, dtype=torch.long)
-
-        # Patch the forward method of spec_augment (nn.Module) to spy on calls
-        with patch.object(model.spec_augment, "forward", wraps=model.spec_augment.forward) as spy:
-            model(
-                input_ids=input_ids,
-                input_features=input_features,
-                audio_attention_mask=audio_attention_mask,
-                attention_mask=torch.ones_like(input_ids),
-            )
-            spy.assert_called_once()
-
-
 class TestSavePretrained:
     """save_pretrained writes config, weights, tokenizer, and source files."""
 

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -1,168 +1,14 @@
-"""Tests for RIR and noise augmentation.
+"""Tests for noise augmentation.
 
-RIR tests bypass pool generation by injecting a pre-built ``rirs=`` pool, so
-they don't pay the multi-second pyroomacoustics generation cost in unit
-tests. Noise tests exercise torch-audiomentations on CPU directly. Corpus
-loading is exercised against synthetic WAVs written to ``tmp_path``.
+Noise tests exercise torch-audiomentations on CPU directly. Corpus loading
+is exercised against synthetic WAVs written to ``tmp_path``.
 """
 
 import numpy as np
 import pytest
 import soundfile as sf
-import torch
 
-from tiny_audio.augmentation import (
-    GainPerturbationAugmentation,
-    NoiseAugmentation,
-    RIRAugmentation,
-)
-
-
-def _synthetic_rir(length: int = 1600) -> torch.Tensor:
-    rir = torch.zeros(length, dtype=torch.float32)
-    rir[0] = 1.0
-    rir[100:200] = torch.linspace(0.5, 0, 100)
-    norm = torch.linalg.norm(rir)
-    return rir / norm
-
-
-@pytest.fixture
-def fake_rirs():
-    return [_synthetic_rir() for _ in range(4)]
-
-
-class TestGainPerturbationAugmentation:
-    def test_invalid_range_raises(self):
-        with pytest.raises(ValueError, match="min_gain_db"):
-            GainPerturbationAugmentation(min_gain_db=6.0, max_gain_db=-6.0)
-
-    def test_invalid_prob_raises(self):
-        with pytest.raises(ValueError, match="prob"):
-            GainPerturbationAugmentation(prob=1.5)
-
-    def test_passthrough_at_prob_zero(self):
-        aug = GainPerturbationAugmentation(prob=0.0)
-        audio = np.random.RandomState(0).randn(16000).astype(np.float32) * 0.1
-        assert np.array_equal(aug(audio), audio)
-
-    def test_zero_db_range_is_identity(self):
-        aug = GainPerturbationAugmentation(min_gain_db=0.0, max_gain_db=0.0, prob=1.0)
-        audio = np.random.RandomState(0).randn(16000).astype(np.float32) * 0.1
-        np.testing.assert_allclose(aug(audio), audio, rtol=1e-6)
-
-    def test_dtype_and_shape_preserved(self):
-        aug = GainPerturbationAugmentation(prob=1.0)
-        audio = np.random.RandomState(0).randn(16000).astype(np.float32) * 0.1
-        out = aug(audio)
-        assert out.shape == audio.shape
-        assert out.dtype == audio.dtype
-
-    def test_peak_clamped_below_one(self):
-        aug = GainPerturbationAugmentation(min_gain_db=20.0, max_gain_db=20.0, prob=1.0)
-        audio = np.full(16000, 0.5, dtype=np.float32)
-        out = aug(audio)
-        assert float(np.abs(out).max()) <= 1.0 + 1e-6
-
-    def test_empty_audio_passthrough(self):
-        aug = GainPerturbationAugmentation(prob=1.0)
-        empty = np.zeros(0, dtype=np.float32)
-        out = aug(empty)
-        assert out.shape == empty.shape
-        assert out.dtype == empty.dtype
-
-
-class TestRIRAugmentation:
-    def test_empty_pool_raises(self):
-        with pytest.raises(ValueError, match="Empty RIR pool"):
-            RIRAugmentation(rirs=[])
-
-    def test_output_shape_and_dtype_preserved(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        audio = np.random.randn(16000).astype(np.float32) * 0.1
-        out = aug(audio)
-        assert out.shape == audio.shape
-        assert out.dtype == audio.dtype
-
-    def test_passthrough_at_prob_zero(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=0.0)
-        audio = np.random.randn(16000).astype(np.float32) * 0.1
-        assert np.array_equal(aug(audio), audio)
-
-    def test_modifies_audio_at_prob_one(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        audio = np.random.randn(16000).astype(np.float32) * 0.1
-        out = aug(audio)
-        assert not np.allclose(out, audio)
-
-    def test_amplitude_does_not_clip(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        audio = np.random.randn(16000).astype(np.float32) * 0.5
-        out = aug(audio)
-        assert np.abs(out).max() <= 1.0
-
-    def test_pool_sampling_uses_provided_rirs(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        assert len(aug.rirs) == len(fake_rirs)
-        for got, given in zip(aug.rirs, fake_rirs):
-            assert torch.equal(got, given)
-
-    def test_empty_audio_passthrough(self, fake_rirs):
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        empty = np.zeros(0, dtype=np.float32)
-        out = aug(empty)
-        assert out.shape == empty.shape
-        assert out.dtype == empty.dtype
-
-
-class TestRIRCorpusMode:
-    def _write_synthetic_corpus(self, root, n: int, sample_rate: int = 16000):
-        root.mkdir(parents=True, exist_ok=True)
-        for i in range(n):
-            rir = np.zeros(800, dtype=np.float32)
-            rir[0] = 1.0
-            rir[50:150] = np.linspace(0.4, 0.0, 100, dtype=np.float32)
-            sf.write(str(root / f"rir_{i}.wav"), rir, sample_rate)
-
-    def test_loads_wavs_from_corpus(self, tmp_path):
-        self._write_synthetic_corpus(tmp_path, n=3)
-        aug = RIRAugmentation(corpus_path=str(tmp_path), pool_size=10, prob=1.0)
-        assert len(aug.rirs) == 3
-
-    def test_subsamples_to_pool_size(self, tmp_path):
-        self._write_synthetic_corpus(tmp_path, n=20)
-        aug = RIRAugmentation(corpus_path=str(tmp_path), pool_size=5, prob=1.0, seed=0)
-        assert len(aug.rirs) == 5
-
-    def test_resamples_when_sample_rate_differs(self, tmp_path):
-        # Source RIRs at 24kHz, target sample rate 16kHz — loader must resample.
-        self._write_synthetic_corpus(tmp_path, n=2, sample_rate=24000)
-        aug = RIRAugmentation(corpus_path=str(tmp_path), pool_size=10, prob=1.0, sample_rate=16000)
-        assert len(aug.rirs) == 2
-        # 800 samples at 24kHz → ~533 samples at 16kHz, post peak-trim ≤ that.
-        assert all(rir.shape[0] <= 600 for rir in aug.rirs)
-
-    def test_missing_corpus_path_raises(self, tmp_path):
-        with pytest.raises(FileNotFoundError):
-            RIRAugmentation(corpus_path=str(tmp_path / "does-not-exist"), prob=1.0)
-
-    def test_empty_corpus_raises(self, tmp_path):
-        tmp_path.mkdir(exist_ok=True)
-        with pytest.raises(ValueError, match="No .wav files"):
-            RIRAugmentation(corpus_path=str(tmp_path), prob=1.0)
-
-    def test_loads_from_multiple_corpus_paths(self, tmp_path):
-        a = tmp_path / "a"
-        b = tmp_path / "b"
-        self._write_synthetic_corpus(a, n=2)
-        self._write_synthetic_corpus(b, n=3)
-        aug = RIRAugmentation(corpus_path=[str(a), str(b)], pool_size=10, prob=1.0)
-        assert len(aug.rirs) == 5
-
-    def test_multiple_corpus_paths_one_missing_raises(self, tmp_path):
-        a = tmp_path / "a"
-        self._write_synthetic_corpus(a, n=2)
-        with pytest.raises(FileNotFoundError):
-            RIRAugmentation(corpus_path=[str(a), str(tmp_path / "does-not-exist")], prob=1.0)
+from tiny_audio.augmentation import NoiseAugmentation
 
 
 class TestNoiseAugmentation:
@@ -186,14 +32,12 @@ class TestNoiseAugmentation:
         assert np.allclose(out, audio, atol=1e-6)
 
     def test_snr_range_respected(self):
-        # With high SNR, output should be close to input
         aug = NoiseAugmentation(prob=1.0, min_snr_db=60.0, max_snr_db=60.0)
         audio = np.random.randn(16000).astype(np.float32) * 0.1
         out = aug(audio)
-        # 60 dB SNR means noise is ~1000x quieter than signal, so output ~= input
         signal_rms = float(np.sqrt(np.mean(audio**2)))
         diff_rms = float(np.sqrt(np.mean((out - audio) ** 2)))
-        assert diff_rms < signal_rms * 0.05  # noise < 5% of signal
+        assert diff_rms < signal_rms * 0.05
 
     def test_empty_audio_passthrough(self):
         aug = NoiseAugmentation(prob=1.0)
@@ -208,8 +52,6 @@ class TestNoiseCorpusMode:
         root.mkdir(parents=True, exist_ok=True)
         rng = np.random.default_rng(0)
         for i in range(n):
-            # 2s of pink-ish broadband noise — enough length for AddBackgroundNoise
-            # to slice clips out of.
             noise = rng.standard_normal(sample_rate * 2).astype(np.float32) * 0.1
             sf.write(str(root / f"noise_{i}.wav"), noise, sample_rate)
 
@@ -257,17 +99,9 @@ class TestNoiseCorpusMode:
 
 
 class TestSilenceInjection:
-    """Tests for silence-injection corpus filtering.
-
-    Silence injection pairs audio with an empty transcript. If the audio
-    were drawn from MUSAN/speech, this would teach the model 'real human
-    speech → emit nothing' — the opposite of what an ASR system should do.
-    ``sample_noise_only`` must skip any path under a ``speech`` subdirectory.
-    Noise *mixing* (cocktail-party robustness) should still use the full pool.
-    """
+    """Silence injection must not draw from MUSAN/speech subdir."""
 
     def _write_musan_like(self, root, sample_rate: int = 16000):
-        """Mimic MUSAN's directory layout with speech/ + noise/ + music/ subdirs."""
         rng = np.random.default_rng(0)
         for sub in ("speech", "noise", "music"):
             d = root / sub
@@ -293,9 +127,6 @@ class TestSilenceInjection:
         assert all("speech" not in p.parts for p in sampled_paths)
 
     def test_sample_noise_only_returns_none_when_only_speech(self, tmp_path):
-        # If the configured corpus contains only speech/, silence injection
-        # has no safe pool — return None so the caller can skip injection
-        # rather than emit a speech-paired-with-empty sample.
         rng = np.random.default_rng(0)
         (tmp_path / "speech").mkdir()
         for i in range(2):
@@ -305,8 +136,6 @@ class TestSilenceInjection:
         assert aug.sample_noise_only(16000) is None
 
     def test_mix_corpus_noise_still_uses_full_pool(self, tmp_path):
-        # Noise *mixing* (cocktail-party robustness) should still draw from
-        # the full pool, including speech/ — only silence-injection skips it.
         self._write_musan_like(tmp_path)
         aug = NoiseAugmentation(prob=1.0, corpus_path=str(tmp_path))
         sampled_paths: list = []
@@ -326,22 +155,6 @@ class TestSilenceInjection:
         )
 
 
-class TestRIRBehavior:
-    """Tests for RIR convolution behavior."""
-
-    def test_rms_restored_after_convolution(self, fake_rirs):
-        # RMS of reverbed output should match input RMS (within tolerance);
-        # without restoration the L2-normalized RIR would attenuate level.
-        aug = RIRAugmentation(rirs=fake_rirs, prob=1.0)
-        audio = np.random.RandomState(0).randn(16000).astype(np.float32) * 0.1
-        in_rms = float(np.sqrt(np.mean(audio**2)))
-        out = aug(audio)
-        out_rms = float(np.sqrt(np.mean(out**2)))
-        # 5% tolerance — peak-clip protection can scale slightly when the
-        # restored signal exceeds [-1, 1].
-        assert abs(out_rms - in_rms) / in_rms < 0.05
-
-
 class TestNoiseMixingPeakProtection:
     def _write_noise_corpus(self, root, n: int = 3, sample_rate: int = 16000):
         rng = np.random.default_rng(0)
@@ -350,15 +163,11 @@ class TestNoiseMixingPeakProtection:
             sf.write(str(root / f"noise_{i}.wav"), arr, sample_rate)
 
     def test_mixed_output_within_unit_range(self, tmp_path):
-        # Loud signal + loud noise at low SNR would exceed [-1, 1] without
-        # post-mix peak protection. Verify the mixer keeps output in range.
         tmp_path.mkdir(parents=True, exist_ok=True)
         self._write_noise_corpus(tmp_path)
-        # Force low-SNR (very loud noise) to make clipping likely.
         aug = NoiseAugmentation(
             prob=1.0, corpus_path=str(tmp_path), min_snr_db=-20.0, max_snr_db=-20.0
         )
-        # Near-full-scale signal.
         audio = np.random.RandomState(0).randn(16000).astype(np.float32) * 0.7
         out = aug(audio)
         peak = float(np.abs(out).max())

--- a/tiny_audio/asr_config.py
+++ b/tiny_audio/asr_config.py
@@ -27,7 +27,7 @@ class ASRConfig(transformers.PretrainedConfig):
     - Text decoder (Qwen)
     - Projector (MLP, MOSA, MoE, QFormer)
     - Generation parameters
-    - Training options (SpecAugment, LoRA)
+    - Training options (LoRA)
     """
 
     model_type = "asr_model"
@@ -61,12 +61,6 @@ class ASRConfig(transformers.PretrainedConfig):
         qformer_num_layers: int = 2,  # Number of QFormer transformer layers
         qformer_num_heads: int = 16,  # Number of attention heads in QFormer
         qformer_intermediate_size: Optional[int] = None,  # FFN size (defaults to 4x hidden)
-        # SpecAugment settings
-        use_specaugment: bool = False,
-        num_time_masks: int = 2,
-        time_mask_length: int = 10,
-        num_freq_masks: int = 0,
-        freq_mask_length: int = 10,
         # LoRA configuration (for Stage 2 fine-tuning)
         use_lora: bool = False,
         lora_rank: int = 8,  # SALMONN default
@@ -96,7 +90,6 @@ class ASRConfig(transformers.PretrainedConfig):
             model_dtype: Model dtype ("bfloat16", "float16", "float32")
             projector_type: Projector architecture ("mlp", "mosa", "moe", "qformer")
             use_lora: Enable LoRA adapters for Stage 2 fine-tuning
-            use_specaugment: Enable SpecAugment data augmentation
         """
         # Set default generation parameters (greedy decoding only).
         # Applied via setattr below — keeping these out of kwargs so they
@@ -134,12 +127,6 @@ class ASRConfig(transformers.PretrainedConfig):
         self.qformer_num_layers = qformer_num_layers
         self.qformer_num_heads = qformer_num_heads
         self.qformer_intermediate_size = qformer_intermediate_size
-        # SpecAugment configuration
-        self.use_specaugment = use_specaugment
-        self.num_time_masks = num_time_masks
-        self.time_mask_length = time_mask_length
-        self.num_freq_masks = num_freq_masks
-        self.freq_mask_length = freq_mask_length
         # LoRA configuration
         self.use_lora = use_lora
         self.lora_rank = lora_rank

--- a/tiny_audio/asr_modeling.py
+++ b/tiny_audio/asr_modeling.py
@@ -24,9 +24,6 @@ except ImportError:
     from projectors import PROJECTOR_CLASSES  # type: ignore[no-redef]
 
 
-from torchaudio.transforms import SpecAugment
-
-
 def _gather_audio_embeds(audio_embeds: torch.Tensor, token_counts: torch.Tensor) -> torch.Tensor:
     """Flatten per-sample audio embeddings into a packed tensor.
 
@@ -186,17 +183,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
         # Freeze projector if specified (for Stage 2 LoRA-only training)
         if getattr(config, "freeze_projector", False):
             self.projector.requires_grad_(False)
-
-        # SpecAugment for data augmentation during training
-        if getattr(config, "use_specaugment", False):
-            self.spec_augment = SpecAugment(
-                n_time_masks=config.num_time_masks,
-                time_mask_param=config.time_mask_length,
-                n_freq_masks=config.num_freq_masks,
-                freq_mask_param=config.freq_mask_length,
-            )
-        else:
-            self.spec_augment = None
 
         # For model parallelism
         self._no_split_modules = getattr(self.language_model, "_no_split_modules", [])
@@ -471,9 +457,6 @@ class ASRModel(PreTrainedModel, GenerationMixin):
             inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
 
         if input_features is not None and input_ids is not None:
-            if self.training and self.spec_augment is not None:
-                input_features = self.spec_augment(input_features)
-
             is_audio_token = input_ids == self.audio_token_id
             if audio_token_counts is None:
                 audio_token_counts = is_audio_token.sum(dim=-1)

--- a/tiny_audio/augmentation.py
+++ b/tiny_audio/augmentation.py
@@ -1,24 +1,7 @@
 """Audio data augmentation utilities for training.
 
-RIR (Room Impulse Response) convolution simulates far-field / reverberant
-recording conditions to close the meeting / distant-mic WER gap when training
-mostly on close-talk audio. Two backends:
-
-  * ``corpus_path`` set — load real recorded RIRs from a directory of WAV
-    files (e.g. OpenSLR-28's ``real_rirs_isotropic_noises``). This is the
-    SOTA recipe (NeMo / Canary / Parakeet).
-  * Otherwise — generate synthetic RIRs on-the-fly via pyroomacoustics'
-    image-source method (CPU, pure-Python — no CUDA toolchain). Faster to
-    set up, slightly less realistic.
-
 NoiseAugmentation mixes background noise from a corpus (MUSAN / OpenSLR /
-WHAM!) at random SNR.
-
-Apply both via dataset.with_transform on the train split. They're decoupled
-so either can be enabled independently. RIR runs first (waveform shaping),
-then noise (additive), matching the standard far-field training recipe.
-
-All required packages are listed in pyproject.toml; no extra install steps.
+WHAM!) at random SNR. Apply via dataset.with_transform on the train split.
 """
 
 from __future__ import annotations
@@ -54,277 +37,6 @@ def _resolve_corpus_roots(corpus_path: str | Sequence[str], hint: str = "") -> l
     return roots
 
 
-class GainPerturbationAugmentation:
-    """Scale the waveform by a random gain in dB.
-
-    Cheap signal-level augmentation. Applied *first* in the chain so noise SNR
-    randomization is computed against the post-gain level — matching what
-    deployment audio looks like (variable mic gain + variable noise floor).
-    """
-
-    def __init__(
-        self,
-        min_gain_db: float = -6.0,
-        max_gain_db: float = 6.0,
-        prob: float = 0.5,
-    ):
-        if not 0.0 <= prob <= 1.0:
-            raise ValueError(f"prob must be in [0, 1], got {prob}")
-        if min_gain_db > max_gain_db:
-            raise ValueError(f"min_gain_db ({min_gain_db}) > max_gain_db ({max_gain_db})")
-        self.min_gain_db = float(min_gain_db)
-        self.max_gain_db = float(max_gain_db)
-        self.prob = prob
-
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
-        if random.random() > self.prob:
-            return audio
-        in_dtype = audio.dtype if hasattr(audio, "dtype") else np.float32
-        gain_db = random.uniform(self.min_gain_db, self.max_gain_db)
-        gain = float(10 ** (gain_db / 20))
-        out = np.asarray(audio, dtype=np.float32) * gain
-        peak = float(np.abs(out).max()) if out.size else 0.0
-        if peak > 1.0:
-            out = out / peak
-        return out.astype(in_dtype)
-
-
-class SpeedPerturbationAugmentation:
-    """Resample audio at a discrete speed factor (default {0.9, 1.0, 1.1}).
-
-    Standard ASR augmentation across NeMo, Wav2Vec2, and Whisper fine-tune
-    recipes — cheap effective-data multiplier that exposes the projector to
-    the encoder's response on the same content at different prosody rates.
-
-    Implementation: relabel the audio's nominal sample rate as
-    ``sample_rate * factor`` and resample back to ``sample_rate``. Output
-    length scales by ``1/factor`` (factor>1 = faster + shorter; factor<1 =
-    slower + longer). Length-changing on purpose; downstream feature
-    extractor pads to longest in the batch.
-
-    Should run FIRST in the augmentation chain — speed perturbation models
-    speaker variation in the source signal, then RIR and noise model the
-    channel applied to that varied source.
-    """
-
-    def __init__(
-        self,
-        sample_rate: int = 16000,
-        factors: Sequence[float] = (0.9, 1.0, 1.1),
-        prob: float = 0.5,
-    ):
-        if not 0.0 <= prob <= 1.0:
-            raise ValueError(f"prob must be in [0, 1], got {prob}")
-        if not factors:
-            raise ValueError("factors must be non-empty")
-        for f in factors:
-            if f <= 0:
-                raise ValueError(f"all factors must be > 0, got {f}")
-        self.sample_rate = sample_rate
-        self.factors = list(factors)
-        self.prob = prob
-
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
-        if random.random() > self.prob:
-            return audio
-        factor = random.choice(self.factors)
-        if factor == 1.0:
-            return audio
-        in_dtype = audio.dtype if hasattr(audio, "dtype") else np.float32
-        audio_t = torch.from_numpy(_to_mono_float32(audio))
-        if audio_t.numel() == 0:
-            return audio
-        relabeled_rate = int(round(self.sample_rate * factor))
-        out = taf.resample(audio_t, relabeled_rate, self.sample_rate)
-        return out.numpy().astype(in_dtype)
-
-
-class RIRAugmentation:
-    """Convolve audio with a random RIR from a pool.
-
-    Pool source:
-      * ``corpus_path`` set — recursively load WAV RIRs from that directory
-        (real recorded RIRs, e.g. OpenSLR-28).
-      * Otherwise — generate ``pool_size`` synthetic RIRs at init by sampling
-        random room geometry / T60 / src+mic positions and running
-        pyroomacoustics' image-source method.
-
-    Pool is held on CPU. Per call, picks a random RIR and convolves with input
-    audio. Output is trimmed to input length aligned to the RIR direct-path
-    peak so frame timing is preserved, then clip-normalized.
-    """
-
-    def __init__(
-        self,
-        sample_rate: int = 16000,
-        prob: float = 0.5,
-        pool_size: int = 2048,
-        corpus_path: str | Sequence[str] | None = None,
-        room_x_range: tuple[float, float] = (3.0, 10.0),
-        room_y_range: tuple[float, float] = (3.0, 10.0),
-        room_z_range: tuple[float, float] = (2.4, 4.0),
-        t60_range: tuple[float, float] = (0.1, 1.0),
-        source_margin: float = 0.3,
-        seed: int | None = None,
-        rirs: list[torch.Tensor] | None = None,
-    ):
-        if rirs is not None:
-            self.rirs = list(rirs)
-        elif corpus_path is not None:
-            self.rirs = self._load_corpus_pool(
-                corpus_path=corpus_path,
-                sample_rate=sample_rate,
-                pool_size=pool_size,
-                seed=seed,
-            )
-        else:
-            self.rirs = self._generate_pool(
-                pool_size=pool_size,
-                sample_rate=sample_rate,
-                room_x_range=room_x_range,
-                room_y_range=room_y_range,
-                room_z_range=room_z_range,
-                t60_range=t60_range,
-                margin=source_margin,
-                seed=seed,
-            )
-        if not self.rirs:
-            raise ValueError("Empty RIR pool")
-        self.sample_rate = sample_rate
-        self.prob = prob
-
-    @staticmethod
-    def _load_corpus_pool(
-        corpus_path: str | Sequence[str],
-        sample_rate: int,
-        pool_size: int,
-        seed: int | None,
-    ) -> list[torch.Tensor]:
-        roots = _resolve_corpus_roots(
-            corpus_path, hint="Run `ta dev download-rirs` to fetch OpenSLR-28."
-        )
-        wav_paths: list[Path] = []
-        for root in roots:
-            wav_paths.extend(root.rglob("*.wav"))
-        wav_paths = sorted(wav_paths)
-        if not wav_paths:
-            raise ValueError(f"No .wav files found under {[str(r) for r in roots]}")
-
-        rng = np.random.default_rng(seed)
-        if pool_size and pool_size < len(wav_paths):
-            picks = rng.choice(len(wav_paths), size=pool_size, replace=False)
-            wav_paths = [wav_paths[i] for i in picks]
-
-        rirs: list[torch.Tensor] = []
-        for path in wav_paths:
-            try:
-                arr, sr = sf.read(str(path), dtype="float32", always_2d=False)
-            except (RuntimeError, OSError, sf.LibsndfileError):
-                continue
-            if arr.ndim > 1:
-                arr = arr.mean(axis=1)
-            wav = torch.from_numpy(np.ascontiguousarray(arr))
-            if sr != sample_rate:
-                wav = taf.resample(wav, sr, sample_rate)
-            peak_idx = int(wav.abs().argmax().item())
-            wav = wav[peak_idx:]
-            norm = torch.linalg.norm(wav)
-            if norm < 1e-8:
-                continue
-            rirs.append(wav / norm)
-        return rirs
-
-    @staticmethod
-    def _generate_pool(
-        pool_size: int,
-        sample_rate: int,
-        room_x_range: tuple[float, float],
-        room_y_range: tuple[float, float],
-        room_z_range: tuple[float, float],
-        t60_range: tuple[float, float],
-        margin: float,
-        seed: int | None,
-    ) -> list[torch.Tensor]:
-        try:
-            import pyroomacoustics as pra
-        except ImportError as e:
-            raise ImportError(
-                "pyroomacoustics is required for on-the-fly RIR generation. "
-                "Install with: pip install pyroomacoustics"
-            ) from e
-
-        rng = np.random.default_rng(seed)
-        rirs: list[torch.Tensor] = []
-        for _ in range(pool_size):
-            room_sz = [
-                float(rng.uniform(*room_x_range)),
-                float(rng.uniform(*room_y_range)),
-                float(rng.uniform(*room_z_range)),
-            ]
-            t60 = float(rng.uniform(*t60_range))
-            pos_src = [
-                float(rng.uniform(margin, room_sz[0] - margin)),
-                float(rng.uniform(margin, room_sz[1] - margin)),
-                float(rng.uniform(margin, room_sz[2] - margin)),
-            ]
-            pos_rcv = [
-                float(rng.uniform(margin, room_sz[0] - margin)),
-                float(rng.uniform(margin, room_sz[1] - margin)),
-                float(rng.uniform(margin, room_sz[2] - margin)),
-            ]
-            try:
-                e_absorption, max_order = pra.inverse_sabine(t60, room_sz)
-            except ValueError:
-                # T60 unreachable for this geometry (room too small / too absorptive).
-                continue
-            room = pra.ShoeBox(
-                room_sz,
-                fs=sample_rate,
-                materials=pra.Material(e_absorption),
-                max_order=max_order,
-            )
-            room.add_source(pos_src)
-            room.add_microphone(pos_rcv)
-            room.compute_rir()
-            assert room.rir is not None
-            rir_np = np.asarray(room.rir[0][0], dtype=np.float32)
-            rir_t = torch.from_numpy(rir_np)
-            peak_idx = int(rir_t.abs().argmax().item())
-            rir_t = rir_t[peak_idx:]
-            norm = torch.linalg.norm(rir_t)
-            if norm < 1e-8:
-                continue
-            rirs.append(rir_t / norm)
-        return rirs
-
-    def __call__(self, audio: np.ndarray) -> np.ndarray:
-        if random.random() > self.prob:
-            return audio
-
-        in_dtype = audio.dtype if hasattr(audio, "dtype") else np.float32
-        audio_t = torch.from_numpy(_to_mono_float32(audio))
-        n = audio_t.shape[-1]
-        if n == 0:
-            return audio
-
-        in_rms = float(torch.sqrt(torch.mean(audio_t**2)))
-
-        rir = random.choice(self.rirs)
-        out = taf.fftconvolve(audio_t, rir, mode="full")[:n]
-
-        # L2-normalized RIRs still attenuate RMS in time, so reverbed clips
-        # end up quieter than the input. Restore level so downstream SNR /
-        # gain decisions see a consistent distribution (NeMo / Canary recipe).
-        out_rms = float(torch.sqrt(torch.mean(out**2)))
-        if in_rms > 1e-8 and out_rms > 1e-8:
-            out = out * (in_rms / out_rms)
-
-        peak = float(out.abs().max())
-        if peak > 1.0:
-            out = out / peak
-        return out.numpy().astype(in_dtype)
-
-
 class NoiseAugmentation:
     """Mix random background noise into audio.
 
@@ -337,8 +49,8 @@ class NoiseAugmentation:
         white / pink / blue / violet noise at random SNR. Cheap, no corpus,
         but lacks real-world temporal / spectral structure.
 
-    Accepts/returns numpy arrays so it can be chained with
-    :class:`RIRAugmentation` in the dataloader transform pipeline.
+    Accepts/returns numpy arrays so it can run in the dataloader transform
+    pipeline.
     """
 
     def __init__(
@@ -348,11 +60,32 @@ class NoiseAugmentation:
         min_snr_db: float = 0.0,
         max_snr_db: float = 25.0,
         corpus_path: str | Sequence[str] | None = None,
+        gaussian_min_snr_db: float | None = None,
+        gaussian_max_snr_db: float | None = None,
+        target_db: float = -25.0,
+        rms_epsilon: float = 1e-2,
+        tile_silence_sec: float = 0.25,
     ):
         self.sample_rate = sample_rate
         self.prob = prob
         self.min_snr_db = min_snr_db
         self.max_snr_db = max_snr_db
+        # When set, an additive Gaussian noise floor is layered on top of the
+        # corpus mix. SNR is sampled uniformly in [gaussian_min_snr_db,
+        # gaussian_max_snr_db] per clip and σ derived from clip RMS — matches
+        # the SpeechBrain / NeMo additive-noise convention.
+        self.gaussian_min_snr_db = gaussian_min_snr_db
+        self.gaussian_max_snr_db = gaussian_max_snr_db
+        # NeMo `NoisePerturbationWithNormalization` parameters: both clean and
+        # noise are normalized to ``target_db`` (dB-FS) before SNR scaling, so
+        # SNR semantics are decoupled from per-clip absolute level. ``rms_epsilon``
+        # protects the divide when a clip is effectively silent. ``tile_silence_sec``
+        # inserts a short silence between repeats when a noise clip is shorter
+        # than the utterance — kills the periodic seam artifact that butt-joined
+        # tiling produces.
+        self.target_db = float(target_db)
+        self.rms_epsilon = float(rms_epsilon)
+        self.tile_silence_sec = float(tile_silence_sec)
         self.noise_paths: list[Path] | None = None
         self.babble_paths: list[Path] = []
         self.non_babble_paths: list[Path] = []
@@ -421,8 +154,18 @@ class NoiseAugmentation:
         if arr.size == 0:
             return None
         if arr.shape[-1] < n_target:
-            repeats = (n_target + arr.shape[-1] - 1) // arr.shape[-1]
-            arr = np.tile(arr, repeats)
+            silence_n = int(round(self.sample_rate * self.tile_silence_sec))
+            silence = np.zeros(silence_n, dtype=arr.dtype)
+            pieces: list[np.ndarray] = []
+            total = 0
+            while total < n_target:
+                pieces.append(arr)
+                total += arr.shape[-1]
+                if total >= n_target:
+                    break
+                pieces.append(silence)
+                total += silence_n
+            arr = np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
         return arr[:n_target]
 
     def _try_read_random_noise(
@@ -449,24 +192,36 @@ class NoiseAugmentation:
                 return noise
         return None
 
+    def _norm_to_target_db(self, x: np.ndarray) -> np.ndarray:
+        """Normalize ``x`` so its RMS matches ``self.target_db`` (dB-FS).
+
+        Mirrors NeMo's ``NoisePerturbationWithNormalization.norm_audio_to_db``:
+        clamp near-zero RMS to ``rms_epsilon`` to avoid divide-by-zero on
+        effectively silent inputs.
+        """
+        rms = float(np.sqrt(np.mean(x**2)))
+        if rms < self.rms_epsilon:
+            rms = self.rms_epsilon
+        scalar = (10 ** (self.target_db / 20.0)) / rms
+        return x * scalar
+
     def _mix_corpus_noise(self, audio: np.ndarray) -> np.ndarray:
         noise = self._try_read_random_noise(audio.shape[-1])
         if noise is None:
             return audio
-        signal_rms = float(np.sqrt(np.mean(audio**2)))
-        noise_rms = float(np.sqrt(np.mean(noise**2)))
-        if signal_rms < 1e-8 or noise_rms < 1e-8:
-            return audio
         snr_db = random.uniform(self.min_snr_db, self.max_snr_db)
-        target_noise_rms = signal_rms / (10 ** (snr_db / 20))
-        noise = noise * (target_noise_rms / noise_rms)
-        mixed = audio + noise.astype(audio.dtype)
+        # NeMo `snr_mixer`: normalize both clean and noise to a common dB-FS
+        # target, then attenuate noise by `-snr_db`. SNR semantics are then
+        # independent of per-clip absolute level (close-talk vs. distant mic).
+        clean = self._norm_to_target_db(audio.astype(np.float32))
+        noise = self._norm_to_target_db(noise.astype(np.float32))
+        mixed = clean + noise * (10 ** (-snr_db / 20.0))
         # Float32 won't physically clip, but downstream mel extraction expects
         # in-range samples — renormalize if mixing pushed the peak above 1.0.
         peak = float(np.abs(mixed).max())
         if peak > 1.0:
             mixed = mixed / peak
-        return mixed
+        return mixed.astype(audio.dtype)
 
     def __call__(self, audio: np.ndarray) -> np.ndarray:
         in_dtype = audio.dtype if hasattr(audio, "dtype") else np.float32
@@ -475,7 +230,17 @@ class NoiseAugmentation:
             if random.random() > self.prob:
                 return audio
             arr = _to_mono_float32(audio)
-            return self._mix_corpus_noise(arr).astype(in_dtype)
+            arr = self._mix_corpus_noise(arr)
+            if self.gaussian_min_snr_db is not None and self.gaussian_max_snr_db is not None:
+                signal_rms = float(np.sqrt(np.mean(arr**2)))
+                if signal_rms >= 1e-8:
+                    snr_db = random.uniform(self.gaussian_min_snr_db, self.gaussian_max_snr_db)
+                    target_std = signal_rms / (10 ** (snr_db / 20))
+                    arr = arr + (np.random.randn(*arr.shape).astype(np.float32) * target_std)
+                    peak = float(np.abs(arr).max())
+                    if peak > 1.0:
+                        arr = arr / peak
+            return arr.astype(in_dtype)
 
         audio_t = torch.from_numpy(_to_mono_float32(audio)).unsqueeze(0).unsqueeze(0)
         out = self.augment(audio_t).samples


### PR DESCRIPTION
## Summary
- Remove label-smoothing override; HF Trainer default + inner CausalLM loss already handle shift and token-correct gradient accumulation correctly. Drop `label_smoothing_factor` from all experiment configs.
- Remove GainPerturbation / SpeedPerturbation / SpecAugment / RIRAugmentation classes, plus the `pyroomacoustics` dep and `ta dev download-rirs` command. Production training only used the noise augmentation; the others were dead config branches.
- Rebuild noise augmentation around the Persian-ELN paper recipe (arXiv:2512.17247): MUSAN `noise/` subset only (~930 ambient clips), SNR uniform in [-15, +15] dB applied to every utterance, plus a per-clip SNR-based additive Gaussian layer (default 20–40 dB).
- Switch the MUSAN mixer to NeMo `NoisePerturbationWithNormalization`: normalize both clean and noise to a common dB-FS target (default -25 dBFS) before SNR scaling, so SNR semantics no longer shift with per-clip absolute level (close-talk vs. distant-mic AMI).
- When a MUSAN clip is shorter than the utterance, insert a 0.25 s silence gap between repeats instead of butt-joining via `np.tile` — removes the periodic seam artifact in the noise spectrum.

## Test plan
- [x] `poetry run pytest tests/test_augmentation.py` — 15 passed
- [x] Full precommit gate (format / lint / type-check / test / build) — 455 tests passed
- [x] dB-FS normalization sanity check: -25 dBFS and -6 dBFS inputs both land at ~-10 dBFS post-mix at SNR=-15 dB (≤3 dB spread vs. ~20 dB pre-fix)
- [ ] End-to-end production training run to confirm WER doesn't regress vs. previous augmentation stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)